### PR TITLE
Fix tiktoken test

### DIFF
--- a/include/pytorch/tokenizers/tiktoken.h
+++ b/include/pytorch/tokenizers/tiktoken.h
@@ -36,8 +36,10 @@ class Tiktoken : public detail::BPETokenizerBase {
       : _special_tokens(std::move(special_tokens)),
         _bos_token_index(bos_token_index),
         _eos_token_index(eos_token_index) {
-    assert(_bos_token_index < _special_tokens->size());
-    assert(_eos_token_index < _special_tokens->size());
+    if (_bos_token_index >= _special_tokens->size() ||
+        _eos_token_index >= _special_tokens->size()) {
+      abort();
+    }
   };
 
   explicit Tiktoken()


### PR DESCRIPTION
Summary:
asserts are optimized away in opt mode: https://fb.workplace.com/groups/codetestingqa/permalink/276290840988681/

assert in the test: https://www.internalfb.com/code/fbsource/[1bbb7754f70b]/fbcode/pytorch/tokenizers/include/pytorch/tokenizers/tiktoken.h?lines=39

Differential Revision: D70428343


