### PR TITLE
Fix build for tokenizer tool script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,5 +86,5 @@ endif()
 
 # Build tools
 if(TOKENIZERS_BUILD_TOOLS)
-  add_subdirectory(tools/tokenize_tool)
+  add_subdirectory(examples/tokenize_tool)
 endif()

--- a/examples/tokenize_tool/CMakeLists.txt
+++ b/examples/tokenize_tool/CMakeLists.txt
@@ -8,3 +8,6 @@ file(GLOB source_files ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 get_filename_component(tool_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 add_executable(${tool_name} ${source_files})
 target_link_libraries(${tool_name} PRIVATE tokenizers)
+target_include_directories(${tool_name} PRIVATE
+    ${CMAKE_SOURCE_DIR}/include/pytorch/tokenizers
+)


### PR DESCRIPTION
```
mkdir cmake-out
cd cmake-out
cmake -DTOKENIZERS_BUILD_TOOLS=ON ..
cmake --build .
./examples/tokenize_tool/tokenize_tool hf_tokenizer ~/hf/models--Qwen--Qwen2.5-1.5B/snapshots/8faed761d45a263340a0528343f099c05c9a4323/tokenizer.jso
```