### PR TITLE
Port string_integer_map and changes to tiktoken to pytorch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(TOKENIZERS_BUILD_TEST)
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include)
-    target_link_libraries(${test_name} gtest_main tokenizers)
+    target_link_libraries(${test_name} gtest_main GTest::gmock tokenizers)
     add_test(${test_name} "${test_name}")
     set_tests_properties(${test_name} PROPERTIES ENVIRONMENT ${test_env})
   endforeach()

--- a/include/pytorch/tokenizers/string_integer_map.h
+++ b/include/pytorch/tokenizers/string_integer_map.h
@@ -1,0 +1,625 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @lint-ignore-every LICENSELINT
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace tokenizers {
+namespace detail {
+
+/**
+ * StringIntegerMap is an immutable bidirectional map between strings and 64 bit
+ * unsigned integers. The element data is stored in a contiguous array and is
+ * shared between both the string buckets and the integer buckets, offering a
+ * compact representation.
+ *
+ * Variable sized integers are used internally, which are sized based on the
+ * data being stored. Custom hash functions are supported, with a stateful hash
+ * functor being optionally provided at construction time.
+ */
+template <
+    typename TStringHash = std::hash<std::string_view>,
+    typename TIntegerHash = std::hash<std::uint64_t>,
+    typename TAllocator = std::allocator<std::uint8_t>>
+class StringIntegerMap {
+ public:
+  /// @name Constructors
+  /// @{
+
+  /// Default constructor is deleted, as this container is intended to be
+  /// constructed with a map of strings to integers.
+  StringIntegerMap() = delete;
+
+  /**
+   * Construct a StringIntegerMap from a map of strings to integers.  Each
+   * string and integer in the map must be unique.
+   * @param map map of strings to integers
+   */
+  template <typename TMap>
+  explicit StringIntegerMap(const TMap& map);
+
+  /**
+   * Construct a StringIntegerMap from a map of strings to integers, explicitly
+   * intializing the integer and string hash objects.  Each string and integer
+   * in the map must be unique.
+   * @param map map of strings to integers
+   */
+  template <typename TMap>
+  StringIntegerMap(
+      const TMap& map,
+      TStringHash string_hasher,
+      TIntegerHash integer_hasher);
+
+  /// @}
+  /// @name Accessors
+  /// @{
+
+  /**
+   * Attempts to retrieve the integer mapped for the given string.
+   * @param str string to lookup
+   * @return a std::optional containing the integer if the string was found,
+   * std::nullopt otherwise
+   */
+  std::optional<std::uint64_t> tryGetInteger(std::string_view str) const;
+
+  /**
+   * Attempts to retrieve the string mapped for the given integer.
+   * @param integer integer to lookup
+   * @return a std::optional containing the string if the integer was found,
+   * std::nullopt otherwise
+   */
+  std::optional<std::string_view> tryGetString(std::uint64_t integer) const;
+
+  /**
+   * Retrieves the number of elements in the map.
+   * @return the number of elements in the map
+   */
+  std::size_t size() const;
+
+  /**
+   * Retrieves the element in the map at the given index.
+   * @return A pair containing the string and integer at the given index.
+   */
+  std::pair<std::string_view, std::uint64_t> getElement(
+      std::size_t index) const;
+
+  /// @}
+
+ private:
+  template <typename TLogical>
+  class VariableSizedInteger {
+   public:
+    VariableSizedInteger() = default;
+
+    explicit VariableSizedInteger(TLogical max_value) {
+      while (max_value != 0) {
+        ++byte_count_;
+        max_value >>= 8;
+      }
+
+      mask_ = (TLogical(1) << (byte_count_ * 8)) - TLogical(1);
+    }
+
+    std::size_t getByteCount() const {
+      return byte_count_;
+    }
+
+    TLogical getMask() const {
+      return mask_;
+    }
+
+    std::uint8_t* write(std::uint8_t* target, TLogical value) const {
+      std::memcpy(target, &value, byte_count_);
+      return target + byte_count_;
+    }
+
+    TLogical read(const std::uint8_t* source) const {
+      TLogical value;
+      std::memcpy(&value, source, sizeof(TLogical));
+      return value & mask_;
+    }
+
+   private:
+    std::size_t byte_count_ = 0;
+    TLogical mask_ = 0;
+  };
+
+  bool tryGetInteger(std::string_view str, std::uint64_t& result) const;
+
+  bool tryGetString(std::uint64_t integer, std::string_view& result) const;
+
+  std::size_t getBucketIndex(std::string_view value) const;
+
+  std::size_t getBucketIndex(std::uint64_t value) const;
+
+  static std::uint8_t getSmallHash(std::size_t hash);
+
+  /// Get the string data and string small hash stored in the element buffer at
+  /// the The hasher used for strings.
+  const TStringHash string_hasher_ = {};
+
+  /// The hasher used for integers.
+  const TIntegerHash integer_hasher_ = {};
+
+  /// String bucket references.
+  std::vector<std::uint8_t, TAllocator> integer_bucket_data_;
+
+  /// Integer bucket elements.
+  /// Laid out as:
+  /// struct {
+  ///   std::uint64_t integer; - Physically using integer_ bytes.
+  ///   std::size_t string_size; - Physically using string_size_ bytes
+  ///   std::size_t string_offset; - Physically using string_offset_ bytes
+  /// }
+  std::vector<std::uint8_t, TAllocator> integer_element_data_;
+
+  /// String bucket references.
+  std::vector<std::uint8_t, TAllocator> string_bucket_data_;
+
+  /// String bucket elements.
+  /// Laid out as:
+  /// struct {
+  ///   std::uint64_t integer; - Physically using integer_ bytes.
+  ///   std::size_t string_size; - Physically using string_size_ bytes
+  ///   std::uint8_t small_hash; - Using std::uint8_t bytes.
+  ///   char string[string_size]; - String data, not zero terminated.
+  /// }
+  std::vector<std::uint8_t, TAllocator> string_element_data_;
+
+  /// Number of hash buckets to use.
+  std::size_t bucket_count_ = 0;
+
+  /// Number of elements stored in the map.
+  std::size_t size_ = 0;
+
+  /// Variable sized element offset info.
+  VariableSizedInteger<std::size_t> element_offset_;
+
+  /// Variable size string offset info.
+  VariableSizedInteger<std::size_t> string_offset_;
+
+  /// Variable sized string size info.
+  VariableSizedInteger<std::size_t> string_size_;
+
+  /// Variable sized integer info.
+  VariableSizedInteger<std::uint64_t> integer_;
+};
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+template <typename TMap>
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::StringIntegerMap(
+    const TMap& map)
+    : StringIntegerMap(map, TStringHash(), TIntegerHash()) {}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+template <typename TMap>
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::StringIntegerMap(
+    const TMap& map,
+    TStringHash string_hasher,
+    TIntegerHash integer_hasher)
+    : string_hasher_(string_hasher), integer_hasher_(integer_hasher) {
+  assert(map.size() <= std::numeric_limits<std::uint32_t>::max());
+  bucket_count_ = size_ = map.size();
+
+  struct BuilderElement {
+    std::uint64_t integer = 0;
+    std::string_view string;
+    std::size_t hash = 0;
+    std::size_t element_offset = 0;
+  };
+
+  std::vector<BuilderElement> builder_string_elements;
+  std::vector<BuilderElement> builder_integer_elements;
+
+  //
+  // Calculate various item sizes and gather the builder elements.
+  //
+
+  std::size_t largest_string_size = 0;
+  std::uint64_t largest_integer = 0;
+  std::size_t total_string_size = 0;
+
+  for (const auto& [str, integer] : map) {
+    total_string_size += str.size();
+    largest_string_size = std::max(largest_string_size, str.size());
+    largest_integer = std::max(largest_integer, integer);
+    builder_string_elements.push_back({integer, str, string_hasher_(str)});
+    builder_integer_elements.push_back(
+        {integer, str, integer_hasher_(integer)});
+  }
+
+  integer_ = VariableSizedInteger<std::uint64_t>(largest_integer);
+  string_size_ = VariableSizedInteger<std::size_t>(largest_string_size);
+  string_offset_ = VariableSizedInteger<std::size_t>(total_string_size);
+
+  const auto string_element_data_size =
+      ((integer_.getByteCount() + string_size_.getByteCount() + 1) *
+       map.size()) +
+      total_string_size;
+  const auto integer_element_size = integer_.getByteCount() +
+      string_offset_.getByteCount() + string_size_.getByteCount();
+  const auto integer_element_data_size = integer_element_size * map.size();
+
+  element_offset_ = VariableSizedInteger<std::size_t>(
+      std::max(string_element_data_size, integer_element_data_size));
+
+  string_bucket_data_.resize(
+      ((bucket_count_ + 1) * element_offset_.getByteCount()) +
+      sizeof(std::uint64_t));
+  integer_bucket_data_.resize(
+      ((bucket_count_ + 1) * element_offset_.getByteCount()) +
+      sizeof(std::uint64_t));
+
+  //
+  // Set up terminal bucket indices.
+  //
+
+  element_offset_.write(
+      string_bucket_data_.data() +
+          (bucket_count_ * element_offset_.getByteCount()),
+      string_element_data_size);
+  element_offset_.write(
+      integer_bucket_data_.data() +
+          (bucket_count_ * element_offset_.getByteCount()),
+      integer_element_data_size);
+  //
+  // Sort the builder elements.
+  //
+
+  std::sort(
+      std::begin(builder_string_elements),
+      std::end(builder_string_elements),
+      [this](const BuilderElement& first, const BuilderElement& second) {
+        const auto first_bucket = first.hash % bucket_count_;
+        const auto second_bucket = second.hash % bucket_count_;
+        if (first_bucket == second_bucket) {
+          const auto first_small_hash = getSmallHash(first.hash);
+          const auto second_small_hash = getSmallHash(second.hash);
+          return first_small_hash < second_small_hash;
+        }
+
+        return first_bucket < second_bucket;
+      });
+
+  std::sort(
+      std::begin(builder_integer_elements),
+      std::end(builder_integer_elements),
+      [this](const BuilderElement& first, const BuilderElement& second) {
+        const auto first_bucket = first.hash % bucket_count_;
+        const auto second_bucket = second.hash % bucket_count_;
+        if (first_bucket == second_bucket) {
+          return first.integer < second.integer;
+        }
+
+        return first_bucket < second_bucket;
+      });
+
+  //
+  // Lay out the string elements and record their positions.
+  //
+
+  std::unordered_map<std::string_view, std::size_t>
+      string_element_byte_index_map;
+  string_element_data_.resize(string_element_data_size + sizeof(std::uint64_t));
+  auto* string_element = string_element_data_.data();
+  for (auto& builder_element : builder_string_elements) {
+    builder_element.element_offset =
+        string_element - string_element_data_.data();
+
+    auto insert_result = string_element_byte_index_map.insert(
+        {builder_element.string, builder_element.element_offset});
+    assert(insert_result.second);
+    (void)insert_result;
+
+    string_element = integer_.write(string_element, builder_element.integer);
+    string_element =
+        string_size_.write(string_element, builder_element.string.size());
+    *string_element = getSmallHash(builder_element.hash);
+    string_element++;
+    std::memcpy(
+        string_element,
+        builder_element.string.data(),
+        builder_element.string.size());
+    string_element += builder_element.string.size();
+    assert(
+        string_element >= string_element_data_.data() &&
+        string_element <=
+            string_element_data_.data() + string_element_data_size);
+  }
+
+  //
+  // Lay out the integer elements.
+  //
+
+  integer_element_data_.resize(
+      integer_element_data_size + sizeof(std::uint64_t));
+  auto* integer_element = integer_element_data_.data();
+  for (auto& builder_element : builder_integer_elements) {
+    builder_element.element_offset =
+        integer_element - integer_element_data_.data();
+    auto string_element_byte_index_iter =
+        string_element_byte_index_map.find(builder_element.string);
+    assert(
+        string_element_byte_index_iter !=
+        std::end(string_element_byte_index_map));
+    integer_element = integer_.write(integer_element, builder_element.integer);
+    integer_element =
+        string_size_.write(integer_element, builder_element.string.size());
+    integer_element = string_offset_.write(
+        integer_element, string_element_byte_index_iter->second);
+    assert(
+        integer_element >= integer_element_data_.data() &&
+        integer_element <=
+            integer_element_data_.data() + integer_element_data_size);
+  }
+
+  //
+  // Both the string elements and integer elements are laid out in order of
+  // their respective hashes. Generate the hash indexes for the string elements
+  // and integer elements.
+  //
+
+  auto builder_string_elements_iter = std::begin(builder_string_elements);
+  auto builder_integer_elements_iter = std::begin(builder_integer_elements);
+
+  for (std::size_t bucket_idx = 0; bucket_idx < bucket_count_; ++bucket_idx) {
+    auto* string_bucket = string_bucket_data_.data() +
+        (bucket_idx * element_offset_.getByteCount());
+    if (builder_string_elements_iter != std::end(builder_string_elements)) {
+      element_offset_.write(
+          string_bucket, builder_string_elements_iter->element_offset);
+    } else {
+      element_offset_.write(string_bucket, string_element_data_size);
+    }
+
+    auto* integer_bucket = integer_bucket_data_.data() +
+        (bucket_idx * element_offset_.getByteCount());
+    if (builder_integer_elements_iter != std::end(builder_integer_elements)) {
+      element_offset_.write(
+          integer_bucket, builder_integer_elements_iter->element_offset);
+    } else {
+      element_offset_.write(integer_bucket, integer_element_data_size);
+    }
+
+    //
+    // Advance the string element iterator past all string elements that map
+    // into this bucket.
+    //
+
+    while (builder_string_elements_iter != std::end(builder_string_elements) &&
+           getBucketIndex(builder_string_elements_iter->string) == bucket_idx) {
+      ++builder_string_elements_iter;
+    }
+
+    //
+    // Advance the integer element index past all integer elements that map into
+    // this bucket.
+    //
+
+    while (
+        builder_integer_elements_iter != std::end(builder_integer_elements) &&
+        getBucketIndex(builder_integer_elements_iter->integer) == bucket_idx) {
+      ++builder_integer_elements_iter;
+    }
+  }
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+std::optional<std::uint64_t>
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::tryGetInteger(
+    std::string_view str) const {
+  std::uint64_t result;
+  return tryGetInteger(str, result) ? std::optional<std::uint64_t>(result)
+                                    : std::nullopt;
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+bool StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::tryGetInteger(
+    std::string_view str,
+    std::uint64_t& result) const {
+  if (size_ == 0) {
+    return false;
+  }
+
+  const auto hash = string_hasher_(str);
+  const auto bucket_index = hash % bucket_count_;
+  const auto small_hash = getSmallHash(hash);
+
+  const auto* bucket_data = string_bucket_data_.data() +
+      (bucket_index * element_offset_.getByteCount());
+  const auto lower_element_offset = element_offset_.read(bucket_data);
+  const auto upper_element_offset =
+      element_offset_.read(bucket_data + element_offset_.getByteCount());
+
+  const auto integer_size = integer_.getByteCount();
+  const auto string_size_size = string_size_.getByteCount();
+
+  std::size_t element_size = 0;
+  auto* element_data_end = string_element_data_.data() + upper_element_offset;
+  for (auto* element_data = string_element_data_.data() + lower_element_offset;
+       element_data < element_data_end;
+       element_data += element_size) {
+    //
+    // Read the string length.
+    //
+
+    const auto element_string_length =
+        string_size_.read(element_data + integer_size);
+    element_size = integer_size + string_size_size + 1 + element_string_length;
+
+    //
+    // Read the string small hash.
+    //
+
+    const auto element_small_hash =
+        element_data[integer_size + string_size_size];
+    if (element_small_hash < small_hash) {
+      continue;
+    } else if (element_small_hash > small_hash) {
+      break;
+    }
+
+    //
+    // Get a view on the string for a full comparison.
+    //
+
+    std::string_view element_string(
+        reinterpret_cast<const char*>(
+            element_data + integer_size + string_size_size + 1),
+        element_string_length);
+    if (str == element_string) {
+      result = integer_.read(element_data);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+std::optional<std::string_view>
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::tryGetString(
+    std::uint64_t integer) const {
+  std::string_view result;
+  return tryGetString(integer, result) ? std::optional<std::string_view>(result)
+                                       : std::nullopt;
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+bool StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::tryGetString(
+    std::uint64_t integer,
+    std::string_view& result) const {
+  if (size_ == 0) {
+    return false;
+  }
+
+  const auto bucket_index = getBucketIndex(integer);
+
+  const auto* bucket_data = integer_bucket_data_.data() +
+      (bucket_index * element_offset_.getByteCount());
+  const auto lower_element_offset = element_offset_.read(bucket_data);
+  const auto upper_element_offset =
+      element_offset_.read(bucket_data + element_offset_.getByteCount());
+
+  const auto integer_element_size = integer_.getByteCount() +
+      string_offset_.getByteCount() + string_size_.getByteCount();
+  auto* element_data_end = integer_element_data_.data() + upper_element_offset;
+  for (auto* element_data = integer_element_data_.data() + lower_element_offset;
+       element_data < element_data_end;
+       element_data += integer_element_size) {
+    const auto element_integer = integer_.read(element_data);
+    if (element_integer == integer) {
+      const auto element_string_size =
+          string_size_.read(element_data + integer_.getByteCount());
+      const auto element_string_offset = string_offset_.read(
+          element_data + integer_.getByteCount() + string_size_.getByteCount());
+      const auto* string_element =
+          string_element_data_.data() + element_string_offset;
+      const auto* string_data = reinterpret_cast<const char*>(
+          string_element + integer_.getByteCount() +
+          string_size_.getByteCount() + 1);
+      result = std::string_view(string_data, element_string_size);
+      return true;
+    } else if (element_integer > integer) {
+      break;
+    }
+  }
+
+  return false;
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+std::size_t StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::size()
+    const {
+  return size_;
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+std::pair<std::string_view, std::uint64_t>
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::getElement(
+    std::size_t index) const {
+  assert(index < size_);
+
+  const auto integer_size = integer_.getByteCount();
+  const auto string_offset_size = string_offset_.getByteCount();
+  const auto string_size_size = string_size_.getByteCount();
+  const auto element_size =
+      integer_size + string_offset_size + string_size_size;
+  const auto* element_data = &integer_element_data_[index * element_size];
+
+  const auto integer = integer_.read(element_data);
+  element_data += integer_size;
+  const auto string_size = string_size_.read(element_data);
+  element_data += string_size_size;
+  const auto string_offset = string_offset_.read(element_data);
+  const auto* string_data =
+      &string_element_data_
+          [string_offset + integer_size + string_size_size + 1];
+
+  return std::make_pair(
+      std::string_view(reinterpret_cast<const char*>(string_data), string_size),
+      integer);
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+std::size_t
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::getBucketIndex(
+    std::string_view value) const {
+  return string_hasher_(value) % bucket_count_;
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+std::size_t
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::getBucketIndex(
+    std::uint64_t value) const {
+  return integer_hasher_(value) % bucket_count_;
+}
+
+template <typename TStringHash, typename TIntegerHash, typename TAllocator>
+std::uint8_t
+StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::getSmallHash(
+    std::size_t hash) {
+  const auto shift = (sizeof(std::size_t) * 8) - 8;
+  return static_cast<std::uint8_t>(hash >> shift);
+}
+
+template <
+    typename TStringHash = std::hash<std::string_view>,
+    typename TIntegerHash = std::hash<std::uint64_t>,
+    typename TAllocator = std::allocator<std::uint8_t>>
+struct StringIntegerMapTypeBuilder {
+  using Map = StringIntegerMap<TStringHash, TIntegerHash, TAllocator>;
+
+  template <typename TOtherStringHash>
+  using WithStringHash =
+      StringIntegerMapTypeBuilder<TOtherStringHash, TIntegerHash, TAllocator>;
+
+  template <typename TOtherIntegerHash>
+  using WithIntegerHash =
+      StringIntegerMapTypeBuilder<TStringHash, TOtherIntegerHash, TAllocator>;
+
+  template <typename TOtherAllocator>
+  using WithAllocator =
+      StringIntegerMapTypeBuilder<TStringHash, TIntegerHash, TOtherAllocator>;
+};
+
+} // namespace detail
+} // namespace tokenizers

--- a/include/pytorch/tokenizers/tiktoken.h
+++ b/include/pytorch/tokenizers/tiktoken.h
@@ -5,6 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+// @lint-ignore-every LICENSELINT
 
 // Tiktoken header
 // Used by OpenAI, adapted from https://github.com/sewenew/tokenizer
@@ -93,7 +94,7 @@ class Tiktoken : public detail::BPETokenizerBase {
       const std::string& text,
       const T& allowed_special) const;
 
-  detail::Encoder _build_special_token_encoder(ssize_t num_base_tokens) const;
+  detail::TokenMap _build_special_token_map(ssize_t num_base_tokens) const;
 
   std::unique_ptr<std::vector<std::string>> _special_tokens;
   size_t _bos_token_index;

--- a/src/tiktoken.cpp
+++ b/src/tiktoken.cpp
@@ -27,9 +27,11 @@
 
 #include <pytorch/tokenizers/base64.h>
 #include <pytorch/tokenizers/tiktoken.h>
+#include <algorithm>
 #include <cinttypes>
 #include <fstream>
 #include <limits>
+#include <unordered_set>
 #include "re2/re2.h"
 
 namespace tokenizers {
@@ -45,7 +47,8 @@ static Re2UPtr _create_regex(const std::string& pattern) {
   return std::make_unique<re2::RE2>("(" + pattern + ")");
 }
 
-static Re2UPtr _build_special_token_regex(const Encoder& special_encoder) {
+static Re2UPtr _build_special_token_regex(
+    const std::vector<std::pair<std::string, std::uint64_t>>& special_encoder) {
   std::string special_pattern;
   for (const auto& ele : special_encoder) {
     if (!special_pattern.empty()) {
@@ -85,38 +88,24 @@ static Result<std::pair<std::string, uint64_t>> _parse(
   return std::pair{std::move(token), rank};
 }
 
-static Result<Encoder> _load_encoder(const std::string& path) {
+static Result<TokenMap> _load_token_map(const std::string& path) {
   std::ifstream file(path);
   TK_CHECK_OR_RETURN_ERROR(
       file, LoadFailure, "failed to open encoder file: %s", path.c_str());
 
-  Encoder encoder;
+  // Instead of generating couple of large unordered_maps here to only process
+  // them linearly in the TokenMap, just place them in a vector of pairs and
+  // sort them twice, looking for duplicates.  It's still O(n log n) but avoids
+  // the overhead of the unordered_maps.
+
+  std::vector<std::pair<std::string, uint64_t>> pairs;
   std::string line;
   while (std::getline(file, line)) {
     auto [token, rank] = TK_UNWRAP(_parse(line));
-
-    TK_CHECK_OR_RETURN_ERROR(
-        encoder.emplace(std::move(token), rank).second,
-        ParseFailure,
-        "duplicate item: %s",
-        line.c_str());
+    pairs.emplace_back(std::move(token), rank);
   }
 
-  return encoder;
-}
-
-static Result<Decoder> _build_decoder(const Encoder& encoder) {
-  Decoder decoder;
-  for (const auto& [k, v] : encoder) {
-    decoder.emplace(v, k);
-  }
-
-  TK_CHECK_OR_RETURN_ERROR(
-      encoder.size() == decoder.size(),
-      LoadFailure,
-      "duplicate items in encoder");
-
-  return decoder;
+  return buildTokenMap(pairs);
 }
 
 } // namespace
@@ -145,7 +134,7 @@ Tiktoken::_split_with_allowed_special_token(
       break;
     }
 
-    if (allowed_special.count(special) == 1) {
+    if (allowed_special.tryGetInteger(special)) {
       // Found an allowed special token, split the text with it.
 #if __cplusplus >= 202002L
       return std::make_pair(
@@ -169,13 +158,13 @@ Error Tiktoken::_encode(
   std::string piece;
   assert(_regex);
   while (re2::RE2::FindAndConsume(&input, *_regex, &piece)) {
-    auto iter = encoder_.find(piece);
-    if (iter != encoder_.end()) {
+    const auto result = token_map_->tryGetInteger(piece);
+    if (result) {
       last_piece_token_len = 1;
-      ret.push_back(iter->second);
+      ret.push_back(*result);
       continue;
     }
-    auto tokens = TK_UNWRAP(byte_pair_encode_(piece, encoder_));
+    auto tokens = TK_UNWRAP(byte_pair_encode_(piece, *token_map_));
     last_piece_token_len = tokens.size();
     ret.insert(ret.end(), tokens.begin(), tokens.end());
   }
@@ -206,17 +195,15 @@ Tiktoken::_encode_with_special_token(
         _encode(sub_input, tokens, last_piece_token_len));
 
     if (special) {
-      uint64_t token = 0;
-      try {
-        token = special_token_encoder_.at(*special);
-      } catch (const std::out_of_range&) {
+      const auto result = special_token_map_->tryGetInteger(*special);
+      if (!result) {
         // Should never go here, since special pattern includes all special
         // chars.
         TK_LOG(Error, "unknown special token: %s", special->c_str());
         return Error::EncodeFailure;
       }
 
-      tokens.push_back(token);
+      tokens.push_back(*result);
       last_piece_token_len = 0;
     } else {
       break;
@@ -229,23 +216,19 @@ Tiktoken::_encode_with_special_token(
   return std::make_pair(tokens, last_piece_token_len);
 }
 
-Encoder Tiktoken::_build_special_token_encoder(ssize_t num_base_tokens) const {
-  Encoder special_token_encoder;
-  for (ssize_t i = 0; i < _special_tokens->size(); ++i) {
-    special_token_encoder.emplace(_special_tokens->at(i), num_base_tokens + i);
-  }
-  return special_token_encoder;
-}
-
 // -------------------------private method end-------------------------------
 // -------------------------public method start-------------------------------
 
 Error Tiktoken::load(const std::string& path) {
-  encoder_ = TK_UNWRAP(_load_encoder(path));
-  special_token_encoder_ = _build_special_token_encoder(encoder_.size());
+  token_map_.emplace(TK_UNWRAP(_load_token_map(path)));
 
-  decoder_ = TK_UNWRAP(_build_decoder(encoder_));
-  special_token_decoder_ = TK_UNWRAP(_build_decoder(special_token_encoder_));
+  std::vector<std::pair<std::string, uint64_t>> special_token_map;
+  for (std::size_t i = 0; i < _special_tokens->size(); ++i) {
+    special_token_map.emplace_back(
+        _special_tokens->at(i), token_map_->size() + i);
+  }
+
+  special_token_map_.emplace(TokenMap(special_token_map));
 
   _regex = _create_regex(_pattern);
   // Warmup re2 as it is slow on the first run, void the return value as it's
@@ -253,14 +236,16 @@ Error Tiktoken::load(const std::string& path) {
   // https://github.com/google/re2/blob/6dcd83d60f7944926bfd308cc13979fc53dd69ca/re2/fuzzing/re2_fuzzer.cc#L136-L141
   (void)_regex->ReverseProgramSize();
 
-  special_token_regex_ = _build_special_token_regex(special_token_encoder_);
+  special_token_regex_ = _build_special_token_regex(special_token_map);
   // Same as above, warm up re2
   (void)special_token_regex_->ReverseProgramSize();
 
   // initialize vocab_size, bos_tok, eos_tok
-  vocab_size_ = encoder_.size() + special_token_encoder_.size();
-  bos_tok_ = special_token_encoder_.at(_special_tokens->at(_bos_token_index));
-  eos_tok_ = special_token_encoder_.at(_special_tokens->at(_eos_token_index));
+  vocab_size_ = token_map_->size() + special_token_map_->size();
+  bos_tok_ =
+      *special_token_map_->tryGetInteger(_special_tokens->at(_bos_token_index));
+  eos_tok_ =
+      *special_token_map_->tryGetInteger(_special_tokens->at(_eos_token_index));
 
   initialized_ = true;
   return Error::Ok;

--- a/test/fb/TARGETS
+++ b/test/fb/TARGETS
@@ -1,0 +1,30 @@
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load("@fbcode_macros//build_defs:cpp_benchmark.bzl", "cpp_benchmark")
+load("@fbsource//arvr/tools/build_defs:embed_resources.bzl", "embed_resources")
+
+oncall("executorch")
+
+embed_resources(
+    name = "string_integer_map_bench_resources",
+    generated_resources = {
+        "//pytorch/tokenizers/test:test_tiktoken_tokenizer_model": "test_tiktoken_tokenizer_model",
+    },
+    header_path = "pytorch/tokenizers/test/fb",
+    namespace = "string_integer_map_bench",
+    visibility = ["PUBLIC"],
+)
+
+# @nolint
+cpp_benchmark(
+     # @autodeps-skip
+    name = "string_integer_map_bench",
+    srcs = ["string_integer_map_bench.cpp"],
+    preprocessor_flags = ["-DFBCODEBUILD=1"],
+    deps = [
+        "fbsource//third-party/benchmark:benchmark",
+        "//pytorch/tokenizers/test/fb:string_integer_map_bench_resources",
+        "//pytorch/tokenizers:headers",
+    ],
+)

--- a/test/targets.bzl
+++ b/test/targets.bzl
@@ -63,6 +63,23 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "test_string_integer_map",
+        srcs = [
+            "test_string_integer_map.cpp",
+        ],
+        deps = [
+            "//pytorch/tokenizers:headers",
+        ],
+        env = {
+            "RESOURCES_PATH": "$(location :resources)/resources",
+        },
+        platforms = [CXX, ANDROID],  # Cannot bundle resources on Apple platform.
+        external_deps = [
+            "re2",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "test_tiktoken",
         srcs = [
             "test_tiktoken.cpp",
@@ -84,4 +101,10 @@ def define_common_targets():
         srcs = native.glob([
             "resources/**",
         ]),
+    )
+
+    runtime.export_file(
+        name = "test_tiktoken_tokenizer_model",
+        src = "resources/test_tiktoken_tokenizer.model",
+        visibility = ["@EXECUTORCH_CLIENTS", "//pytorch/tokenizers/..."],
     )

--- a/test/test_string_integer_map.cpp
+++ b/test/test_string_integer_map.cpp
@@ -1,0 +1,324 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <pytorch/tokenizers/base64.h>
+#include <pytorch/tokenizers/string_integer_map.h>
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#if defined(__APPLE__) || defined(WIN32) || defined(__linux__)
+#define TEST_MEMORY_COMPARISON 1
+
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+#endif
+
+namespace {
+
+using namespace ::testing;
+using ::base64::decode;
+using ::tokenizers::Error;
+using ::tokenizers::Result;
+using ::tokenizers::detail::StringIntegerMap;
+using ::tokenizers::detail::StringIntegerMapTypeBuilder;
+using TokenizerMap = std::unordered_map<std::string, std::uint64_t>;
+
+static inline std::string _get_resource_path(const std::string& name) {
+  return std::getenv("RESOURCES_PATH") + std::string("/") + name;
+}
+
+} // namespace
+
+class StringIntegerMapTest : public Test {
+ public:
+  void SetUp() override {
+    modelPath_ = std::getenv("RESOURCES_PATH") +
+        std::string("/test_tiktoken_tokenizer.model");
+  }
+
+  Result<TokenizerMap> loadModel() {
+    std::ifstream file(modelPath_);
+    TK_CHECK_OR_RETURN_ERROR(
+        file,
+        ParseFailure,
+        "failed to open encoder file: %s",
+        modelPath_.c_str());
+
+    TokenizerMap model;
+    for (std::string line; std::getline(file, line);) {
+      if (line.empty()) {
+        continue;
+      }
+
+      auto pos = line.find(' ');
+      auto token = TK_UNWRAP(decode({line.data(), pos}));
+      uint64_t rank = 0;
+      try {
+        rank = std::stoul(line.substr(pos + 1));
+      } catch (const std::exception&) {
+        TK_CHECK_OR_RETURN_ERROR(
+            false, ParseFailure, "invalid encoder rank: %s", line.c_str());
+      }
+      model[token] = rank;
+    }
+
+    return model;
+  }
+
+  std::string modelPath_;
+};
+
+#if defined(TEST_MEMORY_COMPARISON) && TEST_MEMORY_COMPARISON
+
+class TrackingAllocatorBase {
+ public:
+  static void reset();
+  static std::size_t getSize();
+
+ protected:
+  static void* allocate(std::size_t size);
+  static void deallocate(void* ptr);
+
+  static std::size_t size_;
+};
+
+void TrackingAllocatorBase::reset() {
+  size_ = 0;
+}
+
+std::size_t TrackingAllocatorBase::getSize() {
+  return size_;
+}
+
+void* TrackingAllocatorBase::allocate(std::size_t size) {
+  void* ptr = malloc(size);
+  if (!ptr) {
+    return nullptr;
+  }
+
+#if defined(WIN32)
+  size_ += _msize(ptr);
+#elif defined(__APPLE__)
+  size_ += malloc_size(const_cast<const void*>(ptr));
+#else
+  size_ += malloc_usable_size(ptr);
+#endif
+
+  return ptr;
+}
+
+void TrackingAllocatorBase::deallocate(void* ptr) {
+  if (!ptr) {
+    return;
+  }
+
+#if defined(WIN32)
+  size_ -= _msize(ptr);
+#elif defined(__APPLE__)
+  size_ -= malloc_size(const_cast<const void*>(ptr));
+#else
+  size_ -= malloc_usable_size(ptr);
+#endif
+
+  free(ptr);
+}
+
+std::size_t TrackingAllocatorBase::size_ = 0;
+
+template <typename T>
+class TrackingAllocator : public TrackingAllocatorBase {
+ public:
+  using value_type = T;
+  TrackingAllocator() noexcept = default;
+  template <class U>
+  explicit TrackingAllocator(TrackingAllocator<U> const&) noexcept {}
+
+  value_type* allocate(std::size_t count) {
+    return static_cast<value_type*>(
+        TrackingAllocatorBase::allocate(count * sizeof(value_type))); // NOLINT
+  }
+
+  void deallocate(value_type* ptr, std::size_t /*count*/) noexcept {
+    TrackingAllocatorBase::deallocate(ptr);
+  }
+};
+
+template <class T, class U>
+bool operator==(
+    TrackingAllocator<T> const&,
+    TrackingAllocator<U> const&) noexcept {
+  return true;
+}
+
+template <class T, class U>
+bool operator!=(
+    TrackingAllocator<T> const& lhs,
+    TrackingAllocator<U> const& rhs) noexcept {
+  return !(lhs == rhs);
+}
+
+#endif
+
+TEST_F(StringIntegerMapTest, CreateFromModel) {
+  const auto res = loadModel();
+  ASSERT_EQ(res.ok(), true);
+  const auto& model = res.get();
+  StringIntegerMap map(model);
+
+  for (const auto& [model_key, model_value] : model) {
+    EXPECT_THAT(map.tryGetInteger(model_key), testing::Optional(model_value))
+        << model_key;
+    EXPECT_THAT(map.tryGetString(model_value), testing::Optional(model_key))
+        << model_value;
+  }
+
+  EXPECT_FALSE(map.tryGetInteger("Ich weiß nicht"));
+  EXPECT_FALSE(map.tryGetString(999999999));
+
+  EXPECT_EQ(map.size(), model.size());
+  std::unordered_set<std::string_view> walked_strings;
+  std::unordered_set<std::uint64_t> walked_integers;
+
+  for (std::size_t index = 0; index < map.size(); ++index) {
+    const auto [str, integer] = map.getElement(index);
+    EXPECT_TRUE(walked_strings.insert(str).second) << "str: " << str;
+    EXPECT_TRUE(walked_integers.insert(integer).second)
+        << "integer: " << integer;
+  }
+}
+
+#if defined(TEST_MEMORY_COMPARISON) && TEST_MEMORY_COMPARISON
+
+TEST_F(StringIntegerMapTest, MemoryConsumptionComparison) {
+  TrackingAllocatorBase::reset();
+  EXPECT_EQ(TrackingAllocatorBase::getSize(), 0);
+
+  const auto res = loadModel();
+  ASSERT_EQ(res.ok(), true);
+  const auto& model = res.get();
+
+  std::size_t string_integer_map_size = 0;
+  {
+    typename StringIntegerMapTypeBuilder<>::WithAllocator<
+        TrackingAllocator<std::uint8_t>>::Map map(model);
+    string_integer_map_size = TrackingAllocatorBase::getSize();
+  }
+
+  EXPECT_EQ(TrackingAllocatorBase::getSize(), 0);
+
+  std::size_t unordered_map_size = 0;
+  {
+    std::unordered_map<
+        std::string,
+        std::uint64_t,
+        std::hash<std::string>,
+        std::equal_to<std::string>,
+        TrackingAllocator<std::pair<const std::string, std::uint64_t>>>
+        strings_to_ints;
+    std::unordered_map<
+        std::uint64_t,
+        std::string,
+        std::hash<std::uint64_t>,
+        std::equal_to<std::uint64_t>,
+        TrackingAllocator<std::pair<const std::uint64_t, std::string>>>
+        ints_to_strings;
+    for (const auto& [k, v] : model) {
+      strings_to_ints.emplace(k, v);
+      ints_to_strings.emplace(v, k);
+    }
+
+    unordered_map_size = TrackingAllocatorBase::getSize();
+  }
+
+  EXPECT_LT(string_integer_map_size, unordered_map_size);
+
+#if 1
+  std::cout << "string integer map size = " << string_integer_map_size
+            << std::endl;
+  std::cout << "unordered map size = " << unordered_map_size << std::endl;
+#endif
+}
+
+#endif
+
+template <std::size_t hash_offset>
+struct FixedHash {
+  std::size_t operator()(const std::string_view& str) const {
+    if (str.empty()) {
+      return hash_offset;
+    }
+
+    return str.size() - 1 + hash_offset;
+  }
+
+  std::size_t operator()(std::uint64_t value) const {
+    if (value == 0) {
+      return hash_offset;
+    }
+
+    return static_cast<std::size_t>(std::log10(value)) + hash_offset;
+  }
+};
+
+template <typename THash>
+class StringIntegerMapHashTest : public Test {
+ public:
+  using Container = typename StringIntegerMapTypeBuilder<>::WithIntegerHash<
+      THash>::template WithStringHash<THash>::Map;
+};
+
+using StringIntegerMapHashTestTypes =
+    ::testing::Types<FixedHash<0>, FixedHash<1>, FixedHash<2>, FixedHash<3>>;
+TYPED_TEST_SUITE(StringIntegerMapHashTest, StringIntegerMapHashTestTypes);
+
+TYPED_TEST(StringIntegerMapHashTest, HashCollisions) {
+  std::unordered_map<std::string, std::uint64_t> source = {
+      {"a", 0},
+      {"b", 1},
+      {"c", 2},
+      {"d", 3},
+  };
+
+  typename TestFixture::Container map(source);
+
+  //
+  // Check that the strings exist in the map.
+  //
+
+  EXPECT_THAT(map.tryGetInteger("a"), Optional(0ull));
+  EXPECT_THAT(map.tryGetInteger("b"), Optional(1ull));
+  EXPECT_THAT(map.tryGetInteger("c"), Optional(2ull));
+  EXPECT_THAT(map.tryGetInteger("d"), Optional(3ull));
+
+  EXPECT_FALSE(map.tryGetInteger("e"));
+
+  //
+  // Check that the integers exist in the map.
+  //
+
+  EXPECT_THAT(map.tryGetString(0), Optional(std::string_view("a")));
+  EXPECT_THAT(map.tryGetString(1), Optional(std::string_view("b")));
+  EXPECT_THAT(map.tryGetString(2), Optional(std::string_view("c")));
+  EXPECT_THAT(map.tryGetString(3), Optional(std::string_view("d")));
+
+  EXPECT_FALSE(map.tryGetString(4));
+
+  //
+  // Test a lookup into the next bucket (which should be empty).
+  //
+
+  EXPECT_FALSE(map.tryGetInteger("aa"));
+  EXPECT_FALSE(map.tryGetInteger("aaa"));
+  EXPECT_FALSE(map.tryGetInteger("aaaa"));
+
+  EXPECT_FALSE(map.tryGetString(10));
+  EXPECT_FALSE(map.tryGetString(100));
+  EXPECT_FALSE(map.tryGetString(1000));
+}


### PR DESCRIPTION
Summary:
This change ports the string_integer_map changes from D69472841 to pytorch.

The string_integer_map implementation has changed slightly.  The constructor now takes a container of std::pairs instead of an explicit std::unordered_map, allowing to be initialized from more allocation-friendly containers.  In tests on some devices, this change brings the allocation cost of a particular corpus down from 19.41MB to 3.23MB, while improving token lookup performance and maintaining a par for rank lookup.

Differential Revision: D71500411
