### PR TITLE
Update pattern key for split pretokenizer

### DIFF
--- a/src/pre_tokenizer.cpp
+++ b/src/pre_tokenizer.cpp
@@ -78,7 +78,7 @@ PreTokenizerConfig& PreTokenizerConfig::parse_json(const json& json_config) {
   type = json_config.at("type");
   if (type == "Split") {
     try {
-      pattern = json_config.at("pattern");
+      pattern = json_config.at("pattern").at("Regex");
     } catch (json::out_of_range&) {
     }
   } else if (type == "Digits") {

--- a/test/test_pre_tokenizer.cpp
+++ b/test/test_pre_tokenizer.cpp
@@ -221,7 +221,8 @@ TEST_F(PreTokenizerConfigTest, Split) {
           .parse_json(json{
               {"type", "Split"},
               {"pattern",
-               R"((?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+)"},
+               {{"Regex",
+                 R"((?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+)"}}},
           })
           .create();
   assert_split_match(*ptok, "Hello World", {"Hello", " World"});


### PR DESCRIPTION
Was missing the "Regex" key, e.g.

```
"pretokenizers": [
      {
        "type": "Split",
        "pattern": {
          "Regex": "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]*[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]+[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+"
        },
        "behavior": "Removed",
        "invert": true
      },
      ...
]
```

Test (looking into addressing the invalid perl operator negative lookahead):
```
>> cmake-out/examples/tokenize_tool/tokenize_tool hf_tokenizer ~/hf/models--microsoft--Phi-4-mini-instruct/snapshots/c0fb9e74abda11b496b7907a9c6c9009a7a0488f/tokenizer.json "Hello world!"

WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1743095300.202419 3915421 re2.cc:237] Error parsing '([^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'l...': invalid perl operator: (?!
Vocab Size: 200029
BOS: 199999
EOS: 199999

PROMPT:
Hello world!

Encoding...
E0000 00:00:1743095300.500576 3915421 re2.cc:921] Invalid RE2: invalid perl operator: (?!
[ ]

Decoding...
```