### PR TITLE
Decouple tokenizers from Re2 and use IRegex interface

### DIFF
--- a/include/pytorch/tokenizers/hf_tokenizer.h
+++ b/include/pytorch/tokenizers/hf_tokenizer.h
@@ -15,9 +15,6 @@
 // Standard
 #include <string>
 
-// Third Party
-#include <re2/re2.h>
-
 // Local
 #include <pytorch/tokenizers/bpe_tokenizer_base.h>
 #include <pytorch/tokenizers/error.h>
@@ -43,11 +40,11 @@ class HFTokenizer : public detail::BPETokenizerBase {
 
  private:
   Error _encode(
-      re2::StringPiece& input,
+      const std::string& input,
       std::vector<uint64_t>& ret,
       uint64_t& last_piece_token_len) const override;
 
-  void _decode(re2::StringPiece input, std::string& ret) const override;
+  void _decode(const std::string& input, std::string& ret) const override;
 
   PreTokenizer::Ptr _pretokenizer;
   TokenDecoder::Ptr _decoder;

--- a/include/pytorch/tokenizers/pre_tokenizer.h
+++ b/include/pytorch/tokenizers/pre_tokenizer.h
@@ -19,6 +19,9 @@
 #include <nlohmann/json.hpp>
 #include <re2/re2.h>
 
+// Local
+#include <pytorch/tokenizers/regex.h>
+
 namespace tokenizers {
 
 // -- Base ---------------------------------------------------------------------
@@ -42,7 +45,7 @@ class PreTokenizer {
    *  https://abseil.io/docs/cpp/guides/strings#string_view
    */
   virtual std::vector<std::string> pre_tokenize(
-      re2::StringPiece input) const = 0;
+      const std::string& input) const = 0;
 
   virtual ~PreTokenizer() = default;
 }; // end class PreTokenizer
@@ -138,18 +141,16 @@ class PreTokenizerConfig {
 
 class RegexPreTokenizer : public PreTokenizer {
  public:
-  typedef std::unique_ptr<re2::RE2> Re2UPtr;
-
   explicit RegexPreTokenizer(const std::string& pattern)
       : regex_(RegexPreTokenizer::create_regex_(pattern)) {}
 
   /** Pre-tokenize with the stored regex */
-  std::vector<std::string> pre_tokenize(re2::StringPiece input) const;
+  std::vector<std::string> pre_tokenize(const std::string& input) const;
 
  protected:
-  static Re2UPtr create_regex_(const std::string& pattern);
+  static std::unique_ptr<IRegex> create_regex_(const std::string& pattern);
 
-  Re2UPtr regex_;
+  std::unique_ptr<IRegex> regex_;
 
 }; // end class RegexPreTokenizer
 
@@ -185,7 +186,8 @@ class ByteLevelPreTokenizer : public PreTokenizer {
       : ByteLevelPreTokenizer(true, pattern) {}
 
   /** Perform pre-tokenization */
-  std::vector<std::string> pre_tokenize(re2::StringPiece input) const override;
+  std::vector<std::string> pre_tokenize(
+      const std::string& input) const override;
 
  private:
   const std::string pattern_;
@@ -206,7 +208,8 @@ class SequencePreTokenizer : public PreTokenizer {
   explicit SequencePreTokenizer(std::vector<PreTokenizer::Ptr> pre_tokenizers);
 
   /** Perform pre-tokenization */
-  std::vector<std::string> pre_tokenize(re2::StringPiece input) const override;
+  std::vector<std::string> pre_tokenize(
+      const std::string& input) const override;
 
  private:
   const std::vector<PreTokenizer::Ptr> pre_tokenizers_;

--- a/include/pytorch/tokenizers/result.h
+++ b/include/pytorch/tokenizers/result.h
@@ -186,6 +186,23 @@ T* Result<T>::operator->() {
 } // namespace tokenizers
 
 /**
+ * Unwraps a Result<T> value, throwing a runtime_error if the result contains an
+ * error.
+ *
+ * @param[in] result__ The Result<T> to unwrap
+ */
+#define TK_UNWRAP_THROW(result__)                                     \
+  ({                                                                  \
+    auto unwrap_result__ = (result__);                                \
+    if (!unwrap_result__.ok()) {                                      \
+      throw std::runtime_error(                                       \
+          "Error: " +                                                 \
+          std::to_string(static_cast<int>(unwrap_result__.error()))); \
+    }                                                                 \
+    std::move(unwrap_result__.get());                                 \
+  })
+
+/**
  * Unwrap a Result to obtain its value. If the Result contains an error,
  * propogate the error via trivial function return.
  *

--- a/include/pytorch/tokenizers/tiktoken.h
+++ b/include/pytorch/tokenizers/tiktoken.h
@@ -15,10 +15,11 @@
 #include <cstdint>
 
 // Third Party
-#include "re2/re2.h"
+#include <re2/re2.h>
 
 // Local
 #include <pytorch/tokenizers/bpe_tokenizer_base.h>
+#include <pytorch/tokenizers/regex.h>
 #include <pytorch/tokenizers/result.h>
 #include <pytorch/tokenizers/tokenizer.h>
 
@@ -77,11 +78,11 @@ class Tiktoken : public detail::BPETokenizerBase {
   }
 
   Error _encode(
-      re2::StringPiece& input,
+      const std::string& input,
       std::vector<uint64_t>& ret,
       uint64_t& last_piece_token_len) const override;
 
-  void _decode(re2::StringPiece input, std::string& ret) const override;
+  void _decode(const std::string& input, std::string& ret) const override;
 
   detail::TokenMap _build_special_token_map(ssize_t num_base_tokens) const;
 
@@ -93,7 +94,7 @@ class Tiktoken : public detail::BPETokenizerBase {
   const std::string _pattern =
       R"((?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+)";
 
-  detail::Re2UPtr _regex;
+  std::unique_ptr<IRegex> _regex;
 };
 
 } // namespace tokenizers

--- a/include/pytorch/tokenizers/token_decoder.h
+++ b/include/pytorch/tokenizers/token_decoder.h
@@ -45,7 +45,7 @@ class TokenDecoder {
    *
    * @returns decoded: The decoded token string
    */
-  virtual std::string decode(re2::StringPiece token) const = 0;
+  virtual std::string decode(const std::string& token) const = 0;
 
   // virtual destructor
   virtual ~TokenDecoder() = default;
@@ -92,7 +92,7 @@ class TokenDecoderConfig {
 
 class ByteLevelTokenDecoder : public TokenDecoder {
  public:
-  std::string decode(re2::StringPiece token) const override;
+  std::string decode(const std::string& token) const override;
 
 }; // end class ByteLevelTokenDecoder
 

--- a/src/hf_tokenizer.cpp
+++ b/src/hf_tokenizer.cpp
@@ -100,9 +100,11 @@ Error HFTokenizer::load(const std::string& path) {
 
   // Set up the pre-tokenizer
   try {
+    std::cout << "Setting up pretokenizer..." << std::endl;
     _pretokenizer = PreTokenizerConfig()
                         .parse_json(parsed_json.at("pre_tokenizer"))
                         .create();
+    std::cout << "Pretokenizer set up" << std::endl;
   } catch (const json::out_of_range& e) {
     fprintf(stderr, "Could not parse pre_tokenizer: %s\n", e.what());
     return Error::LoadFailure;
@@ -231,7 +233,7 @@ Error HFTokenizer::load(const std::string& path) {
 // -------------------------private method start--------------------------------
 
 Error HFTokenizer::_encode(
-    re2::StringPiece& input,
+    const std::string& input,
     std::vector<uint64_t>& ret,
     uint64_t& last_piece_token_len) const {
   for (const auto& piece : _pretokenizer->pre_tokenize(input)) {
@@ -249,15 +251,11 @@ Error HFTokenizer::_encode(
   return Error::Ok;
 }
 
-void HFTokenizer::_decode(re2::StringPiece input, std::string& ret) const {
+void HFTokenizer::_decode(const std::string& input, std::string& ret) const {
   if (_decoder) {
     ret += _decoder->decode(input);
   } else {
-#ifdef _USE_INTERNAL_STRING_VIEW
-    ret += input.as_string();
-#else
     ret += input;
-#endif
   }
 }
 

--- a/src/token_decoder.cpp
+++ b/src/token_decoder.cpp
@@ -71,15 +71,14 @@ static std::string format(const char* fmt, ...) {
 
 } // namespace
 
-std::string ByteLevelTokenDecoder::decode(re2::StringPiece token) const {
+std::string ByteLevelTokenDecoder::decode(const std::string& token) const {
   // This is borrowed and lightly tweaked from llama.cpp
   // CITE:
   // https://github.com/ggerganov/llama.cpp/blob/master/src/llama-vocab.cpp#L1755
   std::string decoded_text;
   // TODO: This could be more efficient since what we really need is a string
   //  const ref.
-  std::string text(token);
-  const auto cpts = unicode_cpts_from_utf8(text);
+  const auto cpts = unicode_cpts_from_utf8(token);
   for (const auto cpt : cpts) {
     const auto utf8 = unicode_cpt_to_utf8(cpt);
     try {
@@ -89,7 +88,7 @@ std::string ByteLevelTokenDecoder::decode(re2::StringPiece token) const {
       for (const auto c : utf8) {
         decoded_text += format("%02x", (uint8_t)c);
       }
-      decoded_text += text + "]";
+      decoded_text += token + "]";
     }
   }
 

--- a/targets.bzl
+++ b/targets.bzl
@@ -24,9 +24,32 @@ def define_common_targets():
     )
 
     runtime.cxx_library(
+        name = "regex",
+        srcs = ["src/regex.cpp"] + glob([
+            "src/*_regex.cpp",
+        ]),
+        exported_headers = subdir_glob([
+            ("include", "pytorch/tokenizers/regex.h"),
+            ("include", "pytorch/tokenizers/*_regex.h"),
+        ]),
+        exported_deps = [
+            ":headers",
+        ],
+        exported_external_deps = [
+            "re2",
+        ],
+        visibility = ["//pytorch/tokenizers/..."],
+        header_namespace = "",
+        platforms = PLATFORMS,
+    )
+
+    runtime.cxx_library(
         name = "sentencepiece",
         srcs = [
             "src/sentencepiece.cpp",
+        ],
+        deps = [
+            ":regex",
         ],
         exported_deps = [
             ":headers",
@@ -34,9 +57,6 @@ def define_common_targets():
         visibility = [
             "@EXECUTORCH_CLIENTS",
             "//pytorch/tokenizers/...",
-        ],
-        compiler_flags = [
-            "-D_USE_INTERNAL_STRING_VIEW",
         ],
         external_deps = [
             "sentencepiece",
@@ -51,18 +71,18 @@ def define_common_targets():
             "src/tiktoken.cpp",
             "src/bpe_tokenizer_base.cpp",
         ],
+        deps = [
+            ":regex",
+        ],
         exported_deps = [
             ":headers",
+        ],
+        exported_external_deps = [
+            "re2",
         ],
         visibility = [
             "@EXECUTORCH_CLIENTS",
             "//pytorch/tokenizers/...",
-        ],
-        compiler_flags = [
-            "-D_USE_INTERNAL_STRING_VIEW",
-        ],
-        exported_external_deps = [
-            "re2",
         ],
         platforms = PLATFORMS,
     )
@@ -75,6 +95,9 @@ def define_common_targets():
             "src/pre_tokenizer.cpp",
             "src/token_decoder.cpp",
         ],
+        deps = [
+            ":regex",
+        ],
         exported_deps = [
             ":headers",
             "//pytorch/tokenizers/third-party:unicode",
@@ -82,9 +105,6 @@ def define_common_targets():
         visibility = [
             "@EXECUTORCH_CLIENTS",
             "//pytorch/tokenizers/...",
-        ],
-        compiler_flags = [
-            "-D_USE_INTERNAL_STRING_VIEW",
         ],
         exported_external_deps = [
             "re2",

--- a/test/test_pre_tokenizer.cpp
+++ b/test/test_pre_tokenizer.cpp
@@ -23,8 +23,7 @@ static void assert_split_match(
     const PreTokenizer& ptok,
     const std::string& prompt,
     const std::vector<std::string>& expected) {
-  re2::StringPiece prompt_view(prompt);
-  const auto& got = ptok.pre_tokenize(prompt_view);
+  const auto& got = ptok.pre_tokenize(prompt);
   EXPECT_EQ(expected.size(), got.size());
   for (auto i = 0; i < got.size(); ++i) {
     EXPECT_EQ(expected[i], got[i]);


### PR DESCRIPTION
🧱 Stack:
- [ ] https://github.com/pytorch-labs/tokenizers/pull/45
- [ ] https://github.com/pytorch-labs/tokenizers/pull/48
- [x] https://github.com/pytorch-labs/tokenizers/pull/49
- [ ] https://github.com/pytorch-labs/tokenizers/pull/50

### Testing
Pass CI
```
cmake -DTOKENIZERS_BUILD_TEST=ON -DCMAKE_BUILD_TYPE=Debug . -Bbuild && cmake --build build -j9 --config Debug
(cd build && ctest)
```