### PR TITLE
Pcre2 buck target in third-party (#55)

### DIFF
--- a/targets.bzl
+++ b/targets.bzl
@@ -28,9 +28,6 @@ def define_common_targets():
         srcs = ["src/regex.cpp"] + glob([
             "src/*_regex.cpp",
         ]),
-        deps = [
-            "fbsource//third-party/pcre2:pcre2-8",
-        ],
         exported_headers = subdir_glob([
             ("include", "pytorch/tokenizers/regex.h"),
             ("include", "pytorch/tokenizers/*_regex.h"),
@@ -39,6 +36,7 @@ def define_common_targets():
             ":headers",
         ],
         exported_external_deps = [
+            "pcre2",
             "re2",
         ],
         visibility = ["//pytorch/tokenizers/..."],

--- a/third-party/targets.bzl
+++ b/third-party/targets.bzl
@@ -59,3 +59,55 @@ def define_common_targets():
                 ":abseil",
             ],
         )
+
+        runtime.genrule(
+            name = "config_h_generic",
+            srcs = ["pcre2/src/config.h.generic"],
+            cmd = "cp $SRCS $OUT",
+            out = "pcre2/src/config.h",
+        )
+        runtime.genrule(
+            name = "pcre2_h_generic",
+            srcs = ["pcre2/src/pcre2.h.generic"],
+            cmd = "cp $SRCS $OUT",
+            out = "pcre2/src/pcre2.h",
+        )
+        runtime.genrule(
+            name = "pcre2_chartables_c",
+            srcs = ["pcre2/src/pcre2_chartables.c.dist"],
+            cmd = "cp $SRCS $OUT",
+            out = "pcre2/src/pcre2_chartables.c",
+        )
+
+        runtime.cxx_library(
+            name = "pcre2",
+            srcs = glob([
+                "pcre2/src/*.c",
+            ]) + [
+                ":pcre2_chartables_c",
+            ],
+            exported_headers = [
+                ":pcre2_h_generic",
+            ],
+            headers = [
+                ":config_h_generic",
+            ] + glob([
+                "pcre2/src/*.h",
+            ]),
+            # Preprocessor flags from https://github.com/PCRE2Project/pcre2/blob/2e03e323339ab692640626f02f8d8d6f95bff9c6/BUILD.bazel#L23.
+            preprocessor_flags = [
+                "-DHAVE_CONFIG_H",
+                "-DHAVE_MEMMOVE",
+                "-DHAVE_STRERROR",
+                "-DPCRE2_CODE_UNIT_WIDTH=8",
+                "-DPCRE2_STATIC",
+                "-DSUPPORT_PCRE2_8",
+                "-DSUPPORT_UNICODE",
+            ] + select({
+                "DEFAULT": ["-DHAVE_UNISTD_H"],
+                "ovr_config//os:windows": [],
+            }),
+            _is_external_target = True,
+            public_include_directories = ["pcre2"],
+            visibility = ["PUBLIC"],
+        )


### PR DESCRIPTION
Get https://github.com/pytorch-labs/tokenizers/pull/55 back in, which was closed because of a diff linked to two PRs