### PR TITLE
Fix pcre2 target

### DIFF
--- a/third-party/targets.bzl
+++ b/third-party/targets.bzl
@@ -60,40 +60,61 @@ def define_common_targets():
             ],
         )
 
-        runtime.genrule(
-            name = "config_h_generic",
-            srcs = ["pcre2/src/config.h.generic"],
-            cmd = "cp $SRCS $OUT",
-            out = "pcre2/src/config.h",
-        )
-        runtime.genrule(
-            name = "pcre2_h_generic",
-            srcs = ["pcre2/src/pcre2.h.generic"],
-            cmd = "cp $SRCS $OUT",
-            out = "pcre2/src/pcre2.h",
-        )
+        # runtime.genrule(
+        #     name = "config_h_generic",
+        #     srcs = ["pcre2/src/config.h.generic"],
+        #     cmd = "cp $SRCS $OUT",
+        #     out = "pcre2/src/config.h",
+        # )
+        # runtime.genrule(
+        #     name = "pcre2_h_generic",
+        #     srcs = ["pcre2/src/pcre2.h.generic"],
+        #     cmd = "cp $SRCS $OUT",
+        #     out = "pcre2/src/pcre2.h",
+        # )
         runtime.genrule(
             name = "pcre2_chartables_c",
             srcs = ["pcre2/src/pcre2_chartables.c.dist"],
             cmd = "cp $SRCS $OUT",
             out = "pcre2/src/pcre2_chartables.c",
         )
-
         runtime.cxx_library(
             name = "pcre2",
-            srcs = glob([
-                "pcre2/src/*.c",
-            ]) + [
+            srcs = [
+                "pcre2/src/pcre2_auto_possess.c",
+                "pcre2/src/pcre2_chkdint.c",
+                "pcre2/src/pcre2_compile.c",
+                "pcre2/src/pcre2_compile_cgroup.c",
+                "pcre2/src/pcre2_compile_class.c",
+                "pcre2/src/pcre2_config.c",
+                "pcre2/src/pcre2_context.c",
+                "pcre2/src/pcre2_convert.c",
+                "pcre2/src/pcre2_dfa_match.c",
+                "pcre2/src/pcre2_error.c",
+                "pcre2/src/pcre2_extuni.c",
+                "pcre2/src/pcre2_find_bracket.c",
+                "pcre2/src/pcre2_jit_compile.c",
+                "pcre2/src/pcre2_maketables.c",
+                "pcre2/src/pcre2_match.c",
+                "pcre2/src/pcre2_match_data.c",
+                "pcre2/src/pcre2_match_next.c",
+                "pcre2/src/pcre2_newline.c",
+                "pcre2/src/pcre2_ord2utf.c",
+                "pcre2/src/pcre2_pattern_info.c",
+                "pcre2/src/pcre2_script_run.c",
+                "pcre2/src/pcre2_serialize.c",
+                "pcre2/src/pcre2_string_utils.c",
+                "pcre2/src/pcre2_study.c",
+                "pcre2/src/pcre2_substitute.c",
+                "pcre2/src/pcre2_substring.c",
+                "pcre2/src/pcre2_tables.c",
+                "pcre2/src/pcre2_ucd.c",
+                "pcre2/src/pcre2_valid_utf.c",
+                "pcre2/src/pcre2_xclass.c",
                 ":pcre2_chartables_c",
             ],
-            exported_headers = [
-                ":pcre2_h_generic",
-            ],
-            headers = [
-                ":config_h_generic",
-            ] + glob([
-                "pcre2/src/*.h",
-            ]),
+            exported_headers = {"pcre2.h": "pcre2/src/pcre2.h.generic"},
+            headers = {"config.h": "pcre2/src/config.h.generic"},
             # Preprocessor flags from https://github.com/PCRE2Project/pcre2/blob/2e03e323339ab692640626f02f8d8d6f95bff9c6/BUILD.bazel#L23.
             preprocessor_flags = [
                 "-DHAVE_CONFIG_H",
@@ -107,7 +128,8 @@ def define_common_targets():
                 "DEFAULT": ["-DHAVE_UNISTD_H"],
                 "ovr_config//os:windows": [],
             }),
+            header_namespace = "",
             _is_external_target = True,
-            public_include_directories = ["pcre2"],
+            include_directories = ["pcre2/src"],
             visibility = ["PUBLIC"],
         )

--- a/third-party/targets.bzl
+++ b/third-party/targets.bzl
@@ -60,18 +60,18 @@ def define_common_targets():
             ],
         )
 
-        # runtime.genrule(
-        #     name = "config_h_generic",
-        #     srcs = ["pcre2/src/config.h.generic"],
-        #     cmd = "cp $SRCS $OUT",
-        #     out = "pcre2/src/config.h",
-        # )
-        # runtime.genrule(
-        #     name = "pcre2_h_generic",
-        #     srcs = ["pcre2/src/pcre2.h.generic"],
-        #     cmd = "cp $SRCS $OUT",
-        #     out = "pcre2/src/pcre2.h",
-        # )
+        runtime.genrule(
+            name = "config_h_generic",
+            srcs = ["pcre2/src/config.h.generic"],
+            cmd = "cp $SRCS $OUT",
+            out = "pcre2/src/config.h",
+        )
+        runtime.genrule(
+            name = "pcre2_h_generic",
+            srcs = ["pcre2/src/pcre2.h.generic"],
+            cmd = "cp $SRCS $OUT",
+            out = "pcre2/src/pcre2.h",
+        )
         runtime.genrule(
             name = "pcre2_chartables_c",
             srcs = ["pcre2/src/pcre2_chartables.c.dist"],
@@ -113,8 +113,8 @@ def define_common_targets():
                 "pcre2/src/pcre2_xclass.c",
                 ":pcre2_chartables_c",
             ],
-            exported_headers = {"pcre2.h": "pcre2/src/pcre2.h.generic"},
-            headers = {"config.h": "pcre2/src/config.h.generic"},
+            exported_headers = {"pcre2.h": ":pcre2_h_generic"},
+            headers = {"config.h": ":config_h_generic"},
             # Preprocessor flags from https://github.com/PCRE2Project/pcre2/blob/2e03e323339ab692640626f02f8d8d6f95bff9c6/BUILD.bazel#L23.
             preprocessor_flags = [
                 "-DHAVE_CONFIG_H",


### PR DESCRIPTION
Manually build with oss buck from ET:
```
buck2-bin/buck2-edae27cfca00053d9c5f7c7be81b6b0d7d07573a50be374ce53a9d8692afa5fc build //extension/llm/tokenizers/third-party:pcre2
```

And cquery the Llama runner:
```
buck2-bin/buck2-edae27cfca00053d9c5f7c7be81b6b0d7d07573a50be374ce53a9d8692afa5fc cquery "inputs(deps('//examples/models/llama/runner:runner'))"
```