### PR TITLE
Use weak symbol create_fallback_regex to separate the implementation using PCRE2 and std::regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,9 @@ project(Tokenizers)
 option(TOKENIZERS_BUILD_TEST "Build tests" OFF)
 option(TOKENIZERS_BUILD_TOOLS "Build tools" OFF)
 option(SUPPORT_REGEX_LOOKAHEAD
-    "Support regex lookahead patterns (requires PCRE2)" OFF)
+       "Support regex lookahead patterns (requires PCRE2)" OFF)
 
+include(Utils.cmake)
 # Ignore weak attribute warning
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
 
@@ -34,20 +35,6 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/abseil-cpp)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece)
 
-# Configure PCRE2
-if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
-    set(PCRE2_BUILD_PCRE2_8 ON)
-    set(PCRE2_BUILD_PCRE2_16 OFF)
-    set(PCRE2_BUILD_PCRE2_32 OFF)
-    set(PCRE2_BUILD_TESTS OFF)
-    set(PCRE2_BUILD_PCRE2GREP OFF)
-    set(PCRE2_BUILD_PCRE2TEST OFF)
-    set(PCRE2_BUILD_PCRE2GPERF OFF)
-    set(PCRE2_BUILD_DOCS OFF)
-    set(PCRE2_BUILD_LIBPCRE2_PDB OFF)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2)
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ${_pic_flag})
 
 file(GLOB tokenizers_source_files ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
@@ -60,14 +47,8 @@ set(tokenizers_source_files
     ${CMAKE_CURRENT_SOURCE_DIR}/src/regex.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sentencepiece.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tiktoken.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/token_decoder.cpp
-)
-if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
-    list(APPEND
-        tokenizers_source_files
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/pcre2_regex.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/std_regex.cpp)
-endif()
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/token_decoder.cpp)
+
 file(GLOB unicode_source_files
      ${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/src/*.cpp)
 add_library(tokenizers STATIC ${tokenizers_source_files}
@@ -85,11 +66,26 @@ target_include_directories(
 target_link_libraries(tokenizers PUBLIC sentencepiece-static re2::re2)
 
 if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
-    target_include_directories(tokenizers
-        PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src)
-    target_link_libraries(tokenizers PUBLIC pcre2-8)
-    target_compile_definitions(tokenizers PUBLIC SUPPORT_REGEX_LOOKAHEAD)
+  set(PCRE2_BUILD_PCRE2_8 ON)
+  set(PCRE2_BUILD_PCRE2_16 OFF)
+  set(PCRE2_BUILD_PCRE2_32 OFF)
+  set(PCRE2_BUILD_TESTS OFF)
+  set(PCRE2_BUILD_PCRE2GREP OFF)
+  set(PCRE2_BUILD_PCRE2TEST OFF)
+  set(PCRE2_BUILD_PCRE2GPERF OFF)
+  set(PCRE2_BUILD_DOCS OFF)
+  set(PCRE2_BUILD_LIBPCRE2_PDB OFF)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2)
+  add_library(
+    regex_lookahead STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/pcre2_regex.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/regex_lookahead.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/std_regex.cpp)
+  target_link_libraries(regex_lookahead PUBLIC pcre2-8)
+  target_include_directories(
+    regex_lookahead PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+                           ${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src)
+  target_link_options_shared_lib(regex_lookahead)
 endif()
 
 # Build test
@@ -120,9 +116,9 @@ if(TOKENIZERS_BUILD_TEST)
               ${CMAKE_CURRENT_SOURCE_DIR}/include
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2
-              ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include
-              ${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src)
-    target_link_libraries(${test_name} gtest_main GTest::gmock tokenizers)
+              ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include)
+    target_link_libraries(${test_name} gtest_main GTest::gmock tokenizers
+                          regex_lookahead)
     add_test(${test_name} "${test_name}")
     set_tests_properties(${test_name} PROPERTIES ENVIRONMENT ${test_env})
   endforeach()

--- a/Utils.cmake
+++ b/Utils.cmake
@@ -1,0 +1,50 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#
+# Build tokenizers.
+#
+# ### Editing this file ###
+#
+# This file should be formatted with
+# ~~~
+# cmake-format -i CMakeLists.txt
+# ~~~
+# It should also be cmake-lint clean.
+#
+
+# This is the funtion to use -Wl, --whole-archive to link static library NB:
+# target_link_options is broken for this case, it only append the interface link
+# options of the first library.
+function(kernel_link_options target_name)
+  # target_link_options(${target_name} INTERFACE
+  # "$<LINK_LIBRARY:WHOLE_ARCHIVE,target_name>")
+  target_link_options(
+    ${target_name} INTERFACE "SHELL:LINKER:--whole-archive \
+    $<TARGET_FILE:${target_name}> \
+    LINKER:--no-whole-archive")
+endfunction()
+
+# Same as kernel_link_options but it's for MacOS linker
+function(macos_kernel_link_options target_name)
+  target_link_options(${target_name} INTERFACE
+                      "SHELL:LINKER:-force_load,$<TARGET_FILE:${target_name}>")
+endfunction()
+
+# Same as kernel_link_options but it's for MSVC linker
+function(msvc_kernel_link_options target_name)
+  target_link_options(
+    ${target_name} INTERFACE
+    "SHELL:LINKER:/WHOLEARCHIVE:$<TARGET_FILE:${target_name}>")
+endfunction()
+
+# Ensure that the load-time constructor functions run. By default, the linker
+# would remove them since there are no other references to them.
+function(target_link_options_shared_lib target_name)
+  if(APPLE)
+    macos_kernel_link_options(${target_name})
+  elseif(MSVC)
+    msvc_kernel_link_options(${target_name})
+  else()
+    kernel_link_options(${target_name})
+  endif()
+endfunction()

--- a/include/pytorch/tokenizers/error.h
+++ b/include/pytorch/tokenizers/error.h
@@ -55,6 +55,9 @@ enum class Error : error_code_t {
 
   /// Decode failure.
   DecodeFailure = 0x08,
+
+  /// No suitable regex implementation found.
+  RegexFailure = 0x09,
 };
 
 } // namespace tokenizers

--- a/include/pytorch/tokenizers/pcre2_regex.h
+++ b/include/pytorch/tokenizers/pcre2_regex.h
@@ -45,7 +45,7 @@ class Pcre2Regex : public IRegex {
   pcre2_code* regex_;
   pcre2_match_data* match_data_;
 
-  friend Result<std::unique_ptr<IRegex>> create_regex(
+  friend Result<std::unique_ptr<IRegex>> create_fallback_regex(
       const std::string& pattern);
 };
 

--- a/include/pytorch/tokenizers/regex.h
+++ b/include/pytorch/tokenizers/regex.h
@@ -38,11 +38,24 @@ class IRegex {
 };
 
 /**
- * @brief Creates a regex instance. Tries RE2 first, falls back to std::regex.
+ * @brief Creates a regex instance. If no strong symbol defined, only
+ * uses RE2. This is a weak symbol to allow other regex libraries to be
+ * used.
  *
  * @param pattern The regex pattern to compile.
  * @return A unique pointer to an IRegex-compatible object.
  */
 Result<std::unique_ptr<IRegex>> create_regex(const std::string& pattern);
+
+/**
+ * @brief Creates a fallback regex instance. If no strong symbol defined,
+ * returns Error, otherwise uses PCRE2 and std::regex.
+ * This is a weak symbol to allow other regex libraries to be used.
+ *
+ * @param pattern The regex pattern to compile.
+ * @return A unique pointer to an IRegex-compatible object.
+ */
+Result<std::unique_ptr<IRegex>> create_fallback_regex(
+    const std::string& pattern) TK_WEAK;
 
 } // namespace tokenizers

--- a/src/regex_lookahead.cpp
+++ b/src/regex_lookahead.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// This file contains the implementation of create_regex with lookahead support
+
+#include <pytorch/tokenizers/pcre2_regex.h>
+#include <pytorch/tokenizers/regex.h>
+#include <pytorch/tokenizers/std_regex.h>
+
+#include <iostream>
+#include <memory>
+
+namespace tokenizers {
+
+/**
+ * @brief Factory function that creates a regex object using RE2 if possible.
+ *        Falls back to PCRE2 if RE2 rejects the pattern due to lookahead.
+ *        Falls back to std::regex if PCRE2 also fails.
+ */
+
+#ifdef _MSC_VER
+#pragma weak create_fallback_regex
+#endif // _MSC_VER
+Result<std::unique_ptr<IRegex>> create_fallback_regex(
+    const std::string& pattern) {
+  auto pcre2 = std::make_unique<Pcre2Regex>("(" + pattern + ")");
+
+  if (pcre2->regex_ != nullptr && pcre2->match_data_ != nullptr) {
+    std::cout
+        << "RE2 is unable to support things such as negative lookaheads in "
+        << pattern << ", using PCRE2 instead." << std::endl;
+    return static_cast<std::unique_ptr<IRegex>>(std::move(pcre2));
+  }
+
+  // If PCRE2 also fails, fall back to std::regex
+  try {
+    std::cout << "PCRE2 failed to compile pattern, falling back to std::regex.";
+    auto std_regex = std::make_unique<StdRegex>("(" + pattern + ")");
+    return static_cast<std::unique_ptr<IRegex>>(std::move(std_regex));
+  } catch (const std::regex_error& e) {
+    std::cerr << "std::regex failed: " << e.what() << std::endl;
+    return tokenizers::Error::LoadFailure;
+  }
+}
+
+} // namespace tokenizers

--- a/targets.bzl
+++ b/targets.bzl
@@ -26,8 +26,8 @@ def define_common_targets():
     runtime.cxx_library(
         name = "regex",
         srcs = [
-            "src/regex.cpp",
             "src/re2_regex.cpp",
+            "src/regex.cpp",
         ],
         exported_deps = [
             ":headers",
@@ -44,8 +44,7 @@ def define_common_targets():
         name = "regex_lookahead",
         srcs = [
             "src/pcre2_regex.cpp",
-            "src/regex.cpp",
-            "src/re2_regex.cpp",
+            "src/regex_lookahead.cpp",
             "src/std_regex.cpp",
         ],
         exported_deps = [
@@ -53,10 +52,11 @@ def define_common_targets():
         ],
         exported_external_deps = [
             "pcre2",
-            "re2",
         ],
-        preprocessor_flags = ["-DSUPPORT_REGEX_LOOKAHEAD=ON"],
-        visibility = ["//pytorch/tokenizers/..."],
+        visibility = [
+            "@EXECUTORCH_CLIENTS",
+            "//pytorch/tokenizers/...",
+        ],
         header_namespace = "",
         platforms = PLATFORMS,
     )
@@ -110,29 +110,6 @@ def define_common_targets():
             ":headers",
         ],
         exported_external_deps = [
-            "re2",
-        ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-            "//pytorch/tokenizers/...",
-        ],
-        platforms = PLATFORMS,
-    )
-
-    runtime.cxx_library(
-        name = "tiktoken_lookahead",
-        srcs = [
-            "src/tiktoken.cpp",
-        ],
-        deps = [
-            ":regex_lookahead",
-        ],
-        exported_deps = [
-            ":bpe_tokenizer_base",
-            ":headers",
-        ],
-        exported_external_deps = [
-            "pcre2",
             "re2",
         ],
         visibility = [


### PR DESCRIPTION
Declare and define a weak symbol `create_fallback_regex`, the default implementation is returning an error.

We then build a separate target `regex_lookahead` for PCRE2 and std::regex, to support lookahead feature. This library can be optionally linked into the binary.

