### PR TITLE
Fix cmake for regex lookahead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,7 @@ if(TOKENIZERS_BUILD_TEST)
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2
               ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include)
-    target_link_libraries(${test_name} gtest_main GTest::gmock tokenizers
-                          regex_lookahead)
+    target_link_libraries(${test_name} gtest_main GTest::gmock tokenizers)
     add_test(${test_name} "${test_name}")
     set_tests_properties(${test_name} PROPERTIES ENVIRONMENT ${test_env})
   endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
   target_include_directories(
     regex_lookahead PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
                            ${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src)
-  target_link_options_shared_lib(regex_lookahead)
+			 target_link_options_shared_lib(regex_lookahead)
+  target_link_libraries(tokenizers PUBLIC regex_lookahead)
 endif()
 
 # Build test


### PR DESCRIPTION
Regex lookahead wasn't being linked