### PR TITLE
Enable install find package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,8 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/include>)
 target_link_libraries(tokenizers PUBLIC sentencepiece-static re2::re2)
 
-if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
+if(SUPPORT_REGEX_LOOKAHEAD)
+  set(PCRE2_STATIC_PIC ON)
   set(PCRE2_BUILD_PCRE2_8 ON)
   set(PCRE2_BUILD_PCRE2_16 OFF)
   set(PCRE2_BUILD_PCRE2_32 OFF)
@@ -79,6 +80,11 @@ if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
   set(PCRE2_BUILD_DOCS OFF)
   set(PCRE2_BUILD_LIBPCRE2_PDB OFF)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2)
+
+  # Set the INTERFACE_INCLUDE_DIRECTORIES property for pcre2-8-static
+  set_target_properties(pcre2-8-static PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>
+  )
   add_library(
     regex_lookahead STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pcre2_regex.cpp
@@ -86,45 +92,17 @@ if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/std_regex.cpp)
   target_link_libraries(regex_lookahead PUBLIC pcre2-8)
   target_include_directories(
-    regex_lookahead PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-                           ${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src)
-			 target_link_options_shared_lib(regex_lookahead)
+    regex_lookahead PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>)
+  target_link_options_shared_lib(regex_lookahead)
   target_link_libraries(tokenizers PUBLIC regex_lookahead)
-endif()
-
-# Build test
-if(TOKENIZERS_BUILD_TEST)
-  enable_testing()
-  include(FetchContent)
-  # CMAKE
-  FetchContent_Declare(
-    googletest
-    # Specify the commit you depend on and update it regularly.
-    URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+  install(
+    TARGETS regex_lookahead pcre2-8-static
+    EXPORT tokenizers-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   )
-  set(gtest_force_shared_crt
-      ON
-      CACHE BOOL "" FORCE)
-  FetchContent_MakeAvailable(googletest)
-
-  file(GLOB test_source_files ${CMAKE_CURRENT_SOURCE_DIR}/test/test_*.cpp)
-
-  set(test_env "RESOURCES_PATH=${CMAKE_CURRENT_SOURCE_DIR}/test/resources")
-  foreach(test_source_file ${test_source_files})
-    get_filename_component(test_name ${test_source_file} NAME_WE)
-    message(STATUS "Configuring unit test ${test_name}")
-    add_executable(${test_name} ${test_source_file})
-    target_include_directories(
-      ${test_name}
-      PRIVATE GTEST_INCLUDE_PATH
-              ${CMAKE_CURRENT_SOURCE_DIR}/include
-              ${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece
-              ${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2
-              ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include)
-    target_link_libraries(${test_name} gtest_main GTest::gmock tokenizers)
-    add_test(${test_name} "${test_name}")
-    set_tests_properties(${test_name} PROPERTIES ENVIRONMENT ${test_env})
-  endforeach()
 endif()
 
 # Build tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,12 @@ add_library(tokenizers STATIC ${tokenizers_source_files}
 # Using abseil from sentencepiece/third_party
 target_include_directories(
   tokenizers
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece
-         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece/src
-         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2
-         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include
-         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/include)
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece/src>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/include>)
 target_link_libraries(tokenizers PUBLIC sentencepiece-static re2::re2)
 
 if(SUPPORT_REGEX_LOOKAHEAD OR TOKENIZERS_BUILD_TEST)
@@ -128,3 +128,48 @@ endif()
 if(TOKENIZERS_BUILD_TOOLS)
   add_subdirectory(examples/tokenize_tool)
 endif()
+
+# Installation rules
+include(GNUInstallDirs)
+
+# Install the library and its dependencies
+install(
+  TARGETS tokenizers re2 sentencepiece-static
+  EXPORT tokenizers-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Install header files
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.h"
+)
+
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+# Install the CMake config files
+install(
+  EXPORT tokenizers-targets
+  FILE tokenizers-targets.cmake
+  NAMESPACE tokenizers::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tokenizers
+)
+
+# Generate and install the config file
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tokenizers-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/tokenizers-config.cmake
+  @ONLY
+)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/tokenizers-config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tokenizers
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ option(TOKENIZERS_BUILD_TOOLS "Build tools" OFF)
 option(SUPPORT_REGEX_LOOKAHEAD
        "Support regex lookahead patterns (requires PCRE2)" OFF)
 
+# Include CMakePackageConfigHelpers for configure_package_config_file
+include(CMakePackageConfigHelpers)
 include(Utils.cmake)
+
 # Ignore weak attribute warning
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
 
@@ -163,10 +166,11 @@ install(
 )
 
 # Generate and install the config file
-configure_file(
+configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/tokenizers-config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/tokenizers-config.cmake
-  @ONLY
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tokenizers
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR
 )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,8 @@ project(Tokenizers)
 option(TOKENIZERS_BUILD_TEST "Build tests" OFF)
 option(TOKENIZERS_BUILD_TOOLS "Build tools" OFF)
 option(SUPPORT_REGEX_LOOKAHEAD
-       "Support regex lookahead patterns (requires PCRE2)" OFF)
+       "Support regex lookahead patterns (requires PCRE2)" OFF
+)
 
 # Include CMakePackageConfigHelpers for configure_package_config_file
 include(CMakePackageConfigHelpers)
@@ -50,22 +51,27 @@ set(tokenizers_source_files
     ${CMAKE_CURRENT_SOURCE_DIR}/src/regex.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/sentencepiece.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tiktoken.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/token_decoder.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/token_decoder.cpp
+)
 
 file(GLOB unicode_source_files
-     ${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/src/*.cpp)
-add_library(tokenizers STATIC ${tokenizers_source_files}
-                              ${unicode_source_files})
+     ${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/src/*.cpp
+)
+add_library(
+  tokenizers STATIC ${tokenizers_source_files} ${unicode_source_files}
+)
 
 # Using abseil from sentencepiece/third_party
 target_include_directories(
   tokenizers
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece/src>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include>
-         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/include>)
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/sentencepiece/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/re2>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/include>
+)
 target_link_libraries(tokenizers PUBLIC sentencepiece-static re2::re2)
 
 if(SUPPORT_REGEX_LOOKAHEAD)
@@ -82,18 +88,24 @@ if(SUPPORT_REGEX_LOOKAHEAD)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2)
 
   # Set the INTERFACE_INCLUDE_DIRECTORIES property for pcre2-8-static
-  set_target_properties(pcre2-8-static PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>
+  set_target_properties(
+    pcre2-8-static
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>
   )
   add_library(
     regex_lookahead STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/pcre2_regex.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/regex_lookahead.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/std_regex.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/std_regex.cpp
+  )
   target_link_libraries(regex_lookahead PUBLIC pcre2-8)
   target_include_directories(
-    regex_lookahead PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>)
+    regex_lookahead
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>
+  )
   target_link_options_shared_lib(regex_lookahead)
   target_link_libraries(tokenizers PUBLIC regex_lookahead)
   install(
@@ -126,13 +138,15 @@ install(
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING PATTERN "*.h"
+  FILES_MATCHING
+  PATTERN "*.h"
 )
 
 install(
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/third-party/json/single_include/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING PATTERN "*.hpp"
+  FILES_MATCHING
+  PATTERN "*.hpp"
 )
 
 # Install the CMake config files
@@ -151,7 +165,6 @@ configure_package_config_file(
   PATH_VARS CMAKE_INSTALL_INCLUDEDIR
 )
 
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/tokenizers-config.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tokenizers
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tokenizers-config.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tokenizers
 )

--- a/cmake/tokenizers-config.cmake.in
+++ b/cmake/tokenizers-config.cmake.in
@@ -14,7 +14,10 @@ find_dependency(absl REQUIRED)
 # Directly include sentencepiece library
 set(SENTENCEPIECE_LIBRARY "${CMAKE_INSTALL_PREFIX}/lib64/libsentencepiece.a")
 if(NOT EXISTS "${SENTENCEPIECE_LIBRARY}")
-  message(FATAL_ERROR "Could not find sentencepiece library at ${SENTENCEPIECE_LIBRARY}")
+  message(
+    FATAL_ERROR
+      "Could not find sentencepiece library at ${SENTENCEPIECE_LIBRARY}"
+  )
 endif()
 
 # Include the exported targets file
@@ -25,16 +28,26 @@ set_and_check(TOKENIZERS_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 
 # Add --whole-archive linker flag for tokenizers library
 if(APPLE)
-  set(TOKENIZERS_LINK_OPTIONS "SHELL:-force_load,$<TARGET_FILE:tokenizers::regex_lookahead>")
+  set(TOKENIZERS_LINK_OPTIONS
+      "SHELL:-force_load,$<TARGET_FILE:tokenizers::regex_lookahead>"
+  )
 elseif(MSVC)
-  set(TOKENIZERS_LINK_OPTIONS "SHELL:/WHOLEARCHIVE:$<TARGET_FILE:tokenizers::regex_lookahead>")
+  set(TOKENIZERS_LINK_OPTIONS
+      "SHELL:/WHOLEARCHIVE:$<TARGET_FILE:tokenizers::regex_lookahead>"
+  )
 else()
-  set(TOKENIZERS_LINK_OPTIONS "SHELL:LINKER:--whole-archive $<TARGET_FILE:tokenizers::regex_lookahead> LINKER:--no-whole-archive")
+  set(TOKENIZERS_LINK_OPTIONS
+      "SHELL:LINKER:--whole-archive $<TARGET_FILE:tokenizers::regex_lookahead> LINKER:--no-whole-archive"
+  )
 endif()
 
 # Set the libraries and link options
 set(TOKENIZERS_LIBRARIES tokenizers::tokenizers)
-set_property(TARGET tokenizers::tokenizers APPEND PROPERTY INTERFACE_LINK_OPTIONS "${TOKENIZERS_LINK_OPTIONS}")
+set_property(
+  TARGET tokenizers::tokenizers
+  APPEND
+  PROPERTY INTERFACE_LINK_OPTIONS "${TOKENIZERS_LINK_OPTIONS}"
+)
 
 # Check if the library was found
 check_required_components(tokenizers)

--- a/cmake/tokenizers-config.cmake.in
+++ b/cmake/tokenizers-config.cmake.in
@@ -21,7 +21,7 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/tokenizers-targets.cmake")
 
 # Set the include directories
-set_and_check(TOKENIZERS_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
+set_and_check(TOKENIZERS_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 
 # Set the libraries
 set(TOKENIZERS_LIBRARIES tokenizers::tokenizers)

--- a/cmake/tokenizers-config.cmake.in
+++ b/cmake/tokenizers-config.cmake.in
@@ -23,8 +23,18 @@ include("${CMAKE_CURRENT_LIST_DIR}/tokenizers-targets.cmake")
 # Set the include directories
 set_and_check(TOKENIZERS_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 
-# Set the libraries
+# Add --whole-archive linker flag for tokenizers library
+if(APPLE)
+  set(TOKENIZERS_LINK_OPTIONS "SHELL:-force_load,$<TARGET_FILE:tokenizers::regex_lookahead>")
+elseif(MSVC)
+  set(TOKENIZERS_LINK_OPTIONS "SHELL:/WHOLEARCHIVE:$<TARGET_FILE:tokenizers::regex_lookahead>")
+else()
+  set(TOKENIZERS_LINK_OPTIONS "SHELL:LINKER:--whole-archive $<TARGET_FILE:tokenizers::regex_lookahead> LINKER:--no-whole-archive")
+endif()
+
+# Set the libraries and link options
 set(TOKENIZERS_LIBRARIES tokenizers::tokenizers)
+set_property(TARGET tokenizers::tokenizers APPEND PROPERTY INTERFACE_LINK_OPTIONS "${TOKENIZERS_LINK_OPTIONS}")
 
 # Check if the library was found
 check_required_components(tokenizers)

--- a/cmake/tokenizers-config.cmake.in
+++ b/cmake/tokenizers-config.cmake.in
@@ -1,0 +1,30 @@
+# Config file for the tokenizers package
+# It defines the following variables:
+#  TOKENIZERS_FOUND        - True if the tokenizers library was found
+#  TOKENIZERS_INCLUDE_DIRS - Include directories for tokenizers
+#  TOKENIZERS_LIBRARIES    - Libraries to link against
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Find dependencies
+find_dependency(re2 REQUIRED)
+find_dependency(absl REQUIRED)
+# Directly include sentencepiece library
+set(SENTENCEPIECE_LIBRARY "${CMAKE_INSTALL_PREFIX}/lib64/libsentencepiece.a")
+if(NOT EXISTS "${SENTENCEPIECE_LIBRARY}")
+  message(FATAL_ERROR "Could not find sentencepiece library at ${SENTENCEPIECE_LIBRARY}")
+endif()
+
+# Include the exported targets file
+include("${CMAKE_CURRENT_LIST_DIR}/tokenizers-targets.cmake")
+
+# Set the include directories
+set_and_check(TOKENIZERS_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
+
+# Set the libraries
+set(TOKENIZERS_LIBRARIES tokenizers::tokenizers)
+
+# Check if the library was found
+check_required_components(tokenizers)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,50 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#
+# Build tokenizers tests.
+#
+cmake_minimum_required(VERSION 3.18)
+set(CMAKE_CXX_STANDARD 17)
+
+project(TokenizersTests)
+
+# Include ExternalProject module
+include(FindPackageHandleStandardArgs)
+include(FetchContent)
+include(ExternalProject)
+FetchContent_Declare(
+  tokenizers
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..
+  BUILD_ALWAYS ON
+)
+set(SUPPORT_REGEX_LOOKAHEAD ON)
+FetchContent_MakeAvailable(tokenizers)
+
+# Build test
+FetchContent_Declare(
+  googletest
+  DOWNLOAD_EXTRACT_TIMESTAMP ON
+  # Specify the commit you depend on and update it regularly.
+  URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+)
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+file(GLOB test_source_files test_*.cpp)
+
+set(test_env "RESOURCES_PATH=${CMAKE_CURRENT_SOURCE_DIR}/resources")
+enable_testing()
+foreach(test_source_file ${test_source_files})
+  get_filename_component(test_name ${test_source_file} NAME_WE)
+  message(STATUS "Configuring unit test ${test_name}")
+  add_executable(${test_name} ${test_source_file})
+  target_include_directories(
+    ${test_name}
+    PRIVATE GTEST_INCLUDE_PATH
+            ${TOKENIZERS_INCLUDE_DIRS})
+  target_link_libraries(${test_name} PUBLIC gtest_main GTest::gmock tokenizers)
+  add_test(${test_name} "${test_name}")
+  set_tests_properties(${test_name} PROPERTIES ENVIRONMENT ${test_env})
+endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,9 +13,7 @@ include(FindPackageHandleStandardArgs)
 include(FetchContent)
 include(ExternalProject)
 FetchContent_Declare(
-  tokenizers
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..
-  BUILD_ALWAYS ON
+  tokenizers SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. BUILD_ALWAYS ON
 )
 set(SUPPORT_REGEX_LOOKAHEAD ON)
 FetchContent_MakeAvailable(tokenizers)
@@ -29,7 +27,8 @@ FetchContent_Declare(
 )
 set(gtest_force_shared_crt
     ON
-    CACHE BOOL "" FORCE)
+    CACHE BOOL "" FORCE
+)
 FetchContent_MakeAvailable(googletest)
 
 file(GLOB test_source_files test_*.cpp)
@@ -41,9 +40,8 @@ foreach(test_source_file ${test_source_files})
   message(STATUS "Configuring unit test ${test_name}")
   add_executable(${test_name} ${test_source_file})
   target_include_directories(
-    ${test_name}
-    PRIVATE GTEST_INCLUDE_PATH
-            ${TOKENIZERS_INCLUDE_DIRS})
+    ${test_name} PRIVATE GTEST_INCLUDE_PATH ${TOKENIZERS_INCLUDE_DIRS}
+  )
   target_link_libraries(${test_name} PUBLIC gtest_main GTest::gmock tokenizers)
   add_test(${test_name} "${test_name}")
   set_tests_properties(${test_name} PROPERTIES ENVIRONMENT ${test_env})


### PR DESCRIPTION
This pull request introduces several enhancements to the `CMakeLists.txt` file and adds a new configuration file for the `tokenizers` package. The changes focus on improving build system support, adding installation rules, and providing a package configuration file for easier integration with other projects.

### Build system improvements:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR24-R27): Included `CMakePackageConfigHelpers` to enable the use of `configure_package_config_file` for generating CMake configuration files.
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL60-R68): Updated `target_include_directories` to use `$<BUILD_INTERFACE>` for better handling of include directories during the build process.

### Installation rules:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR134-R179): Added installation rules for the library, headers, and CMake configuration files, including `tokenizers-targets.cmake` and `tokenizers-config.cmake`. These rules ensure the library and its dependencies are correctly installed.

### Package configuration:
* [`cmake/tokenizers-config.cmake.in`](diffhunk://#diff-de93c04cd0b2b1455dacd6ac9bb9edc347bd85c086d745cde5d80de881adf10fR1-R30): Added a new configuration file for the `tokenizers` package, defining variables such as `TOKENIZERS_FOUND`, `TOKENIZERS_INCLUDE_DIRS`, and `TOKENIZERS_LIBRARIES`. It includes dependency checks and ensures the `sentencepiece` library is available.

---------

For any CMake project we should be able to do the following:

```cmake
# add tokenizers
ExternalProject_Add(
  tokenizers_external_project
  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/../tokenizers
  SOURCE_DIR ${EXECUTORCH_ROOT}/extension/llm/tokenizers
  CMAKE_ARGS -DSUPPORT_REGEX_LOOKAHEAD=ON -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/../tokenizers
  INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/../tokenizers
)
add_dependencies(extension_llm_runner tokenizers_external_project)
find_package(tokenizers CONFIG HINTS ${CMAKE_INSTALL_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}/../tokenizers)
```

