### PR TITLE
Revert "Add sentencepiece tokenizer support to llm runner"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(SUPPORT_REGEX_LOOKAHEAD)
     pcre2-8-static
     PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/third-party/pcre2>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>
   )
   add_library(
     regex_lookahead STATIC
@@ -100,10 +100,11 @@ if(SUPPORT_REGEX_LOOKAHEAD)
     ${CMAKE_CURRENT_SOURCE_DIR}/src/regex_lookahead.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/std_regex.cpp
   )
-  target_link_libraries(regex_lookahead PUBLIC pcre2-8-static)
+  target_link_libraries(regex_lookahead PUBLIC pcre2-8)
   target_include_directories(
     regex_lookahead
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/pcre2/src>
   )
   target_link_options_shared_lib(regex_lookahead)
   target_link_libraries(tokenizers PUBLIC regex_lookahead)

--- a/targets.bzl
+++ b/targets.bzl
@@ -101,7 +101,7 @@ def define_common_targets():
             "@EXECUTORCH_CLIENTS",
             "//pytorch/tokenizers/...",
         ],
-        exported_external_deps = [
+        external_deps = [
             "sentencepiece",
             "abseil-cpp",
         ],


### PR DESCRIPTION
This is causing

```
(tr4) [jackzhxng@devvm12068.nha0 ~/tr4/executorch (main)]$ cmake-out/examples/models/llama/llama_main --model_path qwen3_0_6b_new.pte --tokenizer_path ~/hf/models--Qwen--Qwen3-0.6B/snapshots/a9c98e602b9d36d2a2f7ba1eb0f5f31e4e8e5143/tokenizer.json --prompt="Who is th
e president of the US?"                                                                                                                                                                                                                                                   
I tokenizers:regex.cpp:27] Registering override fallback regex                                                                                                                                                                                                            
I tokenizers:regex.cpp:27] Registering override fallback regex                                                                                                                                                                                                            
Setting up pretokenizer...                                                                                                                                                                                                                                                terminate called after throwing an instance of 'std::runtime_error'                                                                                                                                                                                                       
  what():  Unsupported behavior 'Isolated' for Split PreTokenizer. Only 'MergedWithPrevious' is supported.    
```