### PR TITLE
[Windows] sentencepice.lib not libsentencepiece.lib

### DIFF
--- a/cmake/tokenizers-config.cmake.in
+++ b/cmake/tokenizers-config.cmake.in
@@ -11,7 +11,7 @@ include(GNUInstallDirs)
 # Directly include sentencepiece library
 set_and_check(TOKENIZERS_LIBDIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
 if(WIN32)
-    set(SENTENCEPIECE_LIBRARY "${TOKENIZERS_LIBDIR}/libsentencepiece.lib")
+    set(SENTENCEPIECE_LIBRARY "${TOKENIZERS_LIBDIR}/sentencepiece.lib")
 else()
     set(SENTENCEPIECE_LIBRARY "${TOKENIZERS_LIBDIR}/libsentencepiece.a")
 endif()


### PR DESCRIPTION
When building voxtral demo for windows locally Ive found that its installed locally as sentencepiece.lib so need to update what this rule looks for. 