### PR TITLE
Add logging related options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,24 @@ option(SUPPORT_REGEX_LOOKAHEAD
        "Support regex lookahead patterns (requires PCRE2)" OFF
 )
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(_is_build_type_release ON)
+  set(_is_build_type_debug OFF)
+else()
+  set(_is_build_type_release OFF)
+  set(_is_build_type_debug ON)
+endif()
+
+option(TOKENIZERS_ENABLE_LOGGING "Build with TK_LOG_ENABLED" ${_is_build_type_debug})
+
+# Connect with ExecuTorch logging options
+if(DEFINED EXECUTORCH_ENABLE_LOGGING)
+  set(TOKENIZERS_ENABLE_LOGGING ${EXECUTORCH_ENABLE_LOGGING} CACHE BOOL "Build with TK_LOG_ENABLED")
+endif()
+if(DEFINED EXECUTORCH_LOG_LEVEL)
+  set(TOKENIZERS_LOG_LEVEL ${EXECUTORCH_LOG_LEVEL} CACHE STRING "Build with the given TK_LOG_LEVEL value")
+endif()
+
 # Include CMakePackageConfigHelpers for configure_package_config_file
 include(CMakePackageConfigHelpers)
 include(Utils.cmake)
@@ -93,6 +111,12 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third-party/llama.cpp-unicode/include>
 )
 target_link_libraries(tokenizers PUBLIC sentencepiece-static re2::re2)
+
+# Enable logging
+if(TOKENIZERS_ENABLE_LOGGING)
+  target_compile_definitions(tokenizers PUBLIC TK_LOG_ENABLED)
+endif()
+target_compile_definitions(tokenizers PUBLIC TK_LOG_LEVEL=${TOKENIZERS_LOG_LEVEL})
 
 if(SUPPORT_REGEX_LOOKAHEAD)
   set(PCRE2_STATIC_PIC ON)


### PR DESCRIPTION
This pull request updates the `CMakeLists.txt` file to improve how logging is configured for the `tokenizers` build, making it more flexible and consistent with related projects. The main changes add options to enable logging and set log levels based on build type or external variables, and ensure these settings are passed to the build via compile definitions.

**Logging configuration improvements:**

* Added logic to automatically enable logging (`TOKENIZERS_ENABLE_LOGGING`) in debug builds and disable it in release builds, making logging behavior consistent with typical development practices.
* Integrated with ExecuTorch logging options by allowing `TOKENIZERS_ENABLE_LOGGING` and `TOKENIZERS_LOG_LEVEL` to be set from `EXECUTORCH_ENABLE_LOGGING` and `EXECUTORCH_LOG_LEVEL`, respectively, for easier cross-project configuration.

**Build system integration:**

* Updated the build to define `TK_LOG_ENABLED` and `TK_LOG_LEVEL` as compile definitions for the `tokenizers` target, ensuring the logging configuration is available in the code at compile time.

**Test plan:**

* Build in Release mode and see no logging while running the tests:
```
Test project /data/users/larryliu/tokenizers/build/test
      Start  1: test_base64
 1/12 Test  #1: test_base64 ......................   Passed    0.00 sec
      Start  2: test_hf_tokenizer
 2/12 Test  #2: test_hf_tokenizer ................   Passed    0.01 sec
      Start  3: test_isolated_behavior
 3/12 Test  #3: test_isolated_behavior ...........   Passed    0.00 sec
      Start  4: test_llama2c_tokenizer
 4/12 Test  #4: test_llama2c_tokenizer ...........   Passed    0.00 sec
      Start  5: test_normalizer
 5/12 Test  #5: test_normalizer ..................   Passed    0.00 sec
      Start  6: test_pre_tokenizer
 6/12 Test  #6: test_pre_tokenizer ...............   Passed    0.02 sec
      Start  7: test_regex
 7/12 Test  #7: test_regex .......................   Passed    0.00 sec
      Start  8: test_sentencepiece
 8/12 Test  #8: test_sentencepiece ...............   Passed    0.02 sec
      Start  9: test_string_integer_map
 9/12 Test  #9: test_string_integer_map ..........   Passed    0.46 sec
      Start 10: test_tekken
10/12 Test #10: test_tekken ......................   Passed    5.05 sec
      Start 11: test_tiktoken
11/12 Test #11: test_tiktoken ....................   Passed    1.01 sec
      Start 12: test_token_decoder
12/12 Test #12: test_token_decoder ...............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =   6.58 sec
```