### PR TITLE
Upgrade tokenizers build configs to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # It should also be cmake-lint clean.
 #
 cmake_minimum_required(VERSION 3.18)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 project(Tokenizers)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Build tokenizers tests.
 #
 cmake_minimum_required(VERSION 3.18)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 project(TokenizersTests)
 


### PR DESCRIPTION
Summary:
Update CMAKE_CXX_STANDARD from 17 to 20 in tokenizers'
CMakeLists.txt files (main and test).

Differential Revision: D95101104


