### PR TITLE
Fix clang-tidy lint: braces, faster-string-find, unused includes

### DIFF
--- a/src/hf_tokenizer.cpp
+++ b/src/hf_tokenizer.cpp
@@ -10,7 +10,6 @@
 #include <pytorch/tokenizers/hf_tokenizer.h>
 
 // Standard
-#include <algorithm>
 #include <cinttypes>
 #include <filesystem>
 #include <fstream>
@@ -267,16 +266,18 @@ std::vector<uint64_t> HFTokenizer::_byte_pair_merge(
     size_t char_start = i;
     size_t char_len = 1;
     unsigned char byte = static_cast<unsigned char>(piece[i]);
-    if ((byte & 0x80) == 0)
+    if ((byte & 0x80) == 0) {
       char_len = 1;
-    else if ((byte & 0xE0) == 0xC0)
+    } else if ((byte & 0xE0) == 0xC0) {
       char_len = 2;
-    else if ((byte & 0xF0) == 0xE0)
+    } else if ((byte & 0xF0) == 0xE0) {
       char_len = 3;
-    else if ((byte & 0xF8) == 0xF0)
+    } else if ((byte & 0xF8) == 0xF0) {
       char_len = 4;
-    if (char_start + char_len > piece.size())
+    }
+    if (char_start + char_len > piece.size()) {
       char_len = piece.size() - char_start;
+    }
 
     uint64_t token_id = func(char_start, char_start + char_len);
     if (token_id == UINT64_MAX) { // This is the sentinel for byte_fallback
@@ -429,8 +430,9 @@ Error HFTokenizer::parse_merges(const json& parsed_json) {
       std::string first, second;
       if (merge.is_string()) {
         std::string merge_str = merge.get<std::string>();
-        if (merge_str.rfind("#version", 0) == 0)
+        if (merge_str.rfind("#version", 0) == 0) {
           continue;
+        }
         auto space_pos = merge_str.find(' ');
         if (space_pos != std::string::npos) {
           first = merge_str.substr(0, space_pos);
@@ -500,17 +502,21 @@ Error HFTokenizer::setup_special_token_ids(
   }
 
   auto process_config_file = [&](const std::string& file_path) {
-    if (file_path.empty())
+    if (file_path.empty()) {
       return;
+    }
     std::ifstream f(file_path);
-    if (!f)
+    if (!f) {
       return;
+    }
     try {
       json j = json::parse(f);
-      if (j.contains("bos_token"))
+      if (j.contains("bos_token")) {
         config_bos_token = extract_token_string(j["bos_token"]);
-      if (j.contains("eos_token"))
+      }
+      if (j.contains("eos_token")) {
         config_eos_token = extract_token_string(j["eos_token"]);
+      }
       if (config_unk_token.empty() && !explicit_unk_null &&
           j.contains("unk_token")) {
         if (j["unk_token"].is_null()) {

--- a/src/normalizer.cpp
+++ b/src/normalizer.cpp
@@ -121,8 +121,9 @@ std::unique_ptr<IRegex> ReplaceNormalizer::create_regex_(
 }
 
 std::string ReplaceNormalizer::normalize(const std::string& input) const {
-  if (!regex_)
+  if (!regex_) {
     return input;
+  }
 
   std::string result = input;
   auto matches = regex_->find_all(result);

--- a/src/post_processor.cpp
+++ b/src/post_processor.cpp
@@ -10,9 +10,6 @@
 #include <pytorch/tokenizers/log.h>
 #include <pytorch/tokenizers/post_processor.h>
 
-#include <algorithm>
-#include <iostream>
-#include <numeric>
 #include <stdexcept>
 
 using json = nlohmann::json;
@@ -42,12 +39,14 @@ Piece parse_piece(const json& j) {
   if (j.is_string()) {
     std::string s = j.get<std::string>();
     // Check for $A, $B, $0, etc.
-    if (s.rfind("$", 0) == 0) {
+    if (s.rfind('$', 0) == 0) {
       std::string rest = s.substr(1);
-      if (rest == "" || rest == "A" || rest == "a")
+      if (rest == "" || rest == "A" || rest == "a") {
         return Piece::Sequence(SequenceId::A, 0);
-      if (rest == "B" || rest == "b")
+      }
+      if (rest == "B" || rest == "b") {
         return Piece::Sequence(SequenceId::B, 0);
+      }
       // Try parse number
       try {
         uint64_t type_id = std::stoul(rest);
@@ -103,12 +102,14 @@ Template parse_template(const json& j) {
     std::string token;
     while ((pos = s.find(delimiter)) != std::string::npos) {
       token = s.substr(0, pos);
-      if (!token.empty())
+      if (!token.empty()) {
         t.push_back(parse_piece(token));
+      }
       s.erase(0, pos + delimiter.length());
     }
-    if (!s.empty())
+    if (!s.empty()) {
       t.push_back(parse_piece(s));
+    }
   }
   return t;
 }
@@ -120,10 +121,12 @@ std::map<std::string, SpecialToken> parse_special_tokens(const json& j) {
     auto val = it.value();
     SpecialToken st;
     st.id = val.value("id", key);
-    if (val.contains("ids"))
+    if (val.contains("ids")) {
       st.ids = val["ids"].get<std::vector<uint64_t>>();
-    if (val.contains("tokens"))
+    }
+    if (val.contains("tokens")) {
       st.tokens = val["tokens"].get<std::vector<std::string>>();
+    }
     map[key] = st;
   }
   return map;

--- a/src/regex_lookahead.cpp
+++ b/src/regex_lookahead.cpp
@@ -12,7 +12,6 @@
 #include <pytorch/tokenizers/regex.h>
 #include <pytorch/tokenizers/std_regex.h>
 
-#include <iostream>
 #include <memory>
 
 namespace tokenizers {

--- a/src/tekken.cpp
+++ b/src/tekken.cpp
@@ -14,8 +14,6 @@
 
 #include <algorithm>
 #include <fstream>
-#include <iostream>
-#include <sstream>
 
 namespace tokenizers {
 

--- a/src/tiktoken.cpp
+++ b/src/tiktoken.cpp
@@ -27,11 +27,7 @@
 
 #include <pytorch/tokenizers/base64.h>
 #include <pytorch/tokenizers/tiktoken.h>
-#include <algorithm>
-#include <cinttypes>
 #include <fstream>
-#include <limits>
-#include <unordered_set>
 
 namespace tokenizers {
 
@@ -51,7 +47,7 @@ static Result<std::pair<std::string, uint64_t>> _parse(
   // Tiktoken format
   // https://github.com/openai/tiktoken/blob/main/tiktoken/load.py#L140 <base64
   // encoded token str> <rank>
-  auto pos = line.find(" ");
+  auto pos = line.find(' ');
   TK_CHECK_OR_RETURN_ERROR(
       pos != std::string::npos,
       ParseFailure,


### PR DESCRIPTION
Summary:
Fix 3 categories of clang-tidy lint issues in xplat/pytorch/tokenizers/src:

1. readability-braces-around-statements: Add braces around single-statement
   if/else bodies in hf_tokenizer.cpp (10 locations), post_processor.cpp
   (6 locations), and normalizer.cpp (1 location).

2. performance-faster-string-find: Change single-char string literals to
   char literals in tiktoken.cpp and post_processor.cpp (2 locations).

3. facebook-unused-include-check: Remove unused #include directives from
   post_processor.cpp, tekken.cpp, regex_lookahead.cpp, tiktoken.cpp,
   and hf_tokenizer.cpp (11 includes total).

All changes are mechanical and verified with buck2 build.

Differential Revision: D104893053


