### PR TITLE
Fix critical memory safety issues: destructor UB, unvalidated file input, unsigned underflow (#186)

### DIFF
--- a/src/bpe_tokenizer_base.cpp
+++ b/src/bpe_tokenizer_base.cpp
@@ -33,6 +33,10 @@ std::vector<uint64_t> BPETokenizerBase::_byte_pair_merge(
     const std::string& piece,
     const TokenMap& ranks,
     std::function<uint64_t(uint64_t, uint64_t)> func) const {
+  if (piece.empty()) {
+    return {};
+  }
+
   // This is a vector of (start, rank).
   // The rank is of the byte pair starting at position start.
   // The rank of the last item in the vector is not a valid value.
@@ -57,12 +61,15 @@ std::vector<uint64_t> BPETokenizerBase::_byte_pair_merge(
 
   // We look up the ranks once in the beginning and iteratively update
   // them during each merge, which reduces the number of rank lookups.
-  for (auto i = 0U; i < parts.size() - 2; ++i) {
+  for (size_t i = 0; i + 2 < parts.size(); ++i) {
     auto rank = get_rank(parts, i, 0);
     if (rank) {
       // usize::MAX is a sentinel value and cannot be a valid rank
       if (*rank == _max_size()) {
-        TK_LOG(Error, "at %" PRIu32 " rank is too large\n", i);
+        TK_LOG(
+            Error,
+            "at %" PRIu32 " rank is too large\n",
+            static_cast<uint32_t>(i));
       }
       parts[i].second = *rank;
     }

--- a/src/llama2c_tokenizer.cpp
+++ b/src/llama2c_tokenizer.cpp
@@ -8,8 +8,13 @@
 // @lint-ignore-every CLANGTIDY facebook-hte-RelativeInclude
 #include <pytorch/tokenizers/llama2c_tokenizer.h>
 #include <cstring>
+#include <memory>
 
 namespace tokenizers {
+
+// Upper bounds for untrusted file fields to prevent excessive allocation
+static constexpr int32_t kMaxSupportedVocabSize = 10000000; // 10M tokens
+static constexpr int32_t kMaxTokenLengthBytes = 1048576; // 1 MiB
 
 static int compare_tokens(const void* a, const void* b) {
   if (((TokenIndex*)a)->str == nullptr) {
@@ -44,14 +49,15 @@ Error Llama2cTokenizer::load(const std::string& tokenizer_path) {
     return Error::Ok;
   }
   // read in the file
-  FILE* file = fopen(tokenizer_path.c_str(), "rb");
+  std::unique_ptr<FILE, decltype(&fclose)> file(
+      fopen(tokenizer_path.c_str(), "rb"), &fclose);
   if (!file) {
     TK_LOG(Error, "couldn't load %s", tokenizer_path.c_str());
     return Error::LoadFailure;
   }
   int32_t metadata[4];
   for (int i = 0; i < 4; i++) {
-    if (fread(metadata + i, sizeof(int32_t), 1, file) != 1) {
+    if (fread(metadata + i, sizeof(int32_t), 1, file.get()) != 1) {
       TK_LOG(
           Error,
           "Failed to read the metadata at position %d, the tokenizer file is not valid!",
@@ -60,9 +66,23 @@ Error Llama2cTokenizer::load(const std::string& tokenizer_path) {
     }
   }
 
-  // now we have two vocab_sizes one from the model and another from the
-  // tokenizer file.
+  // Validate all metadata before mutating member state, so a failed
+  // retry of load() cannot leave vocab_size_ inconsistent with vocab_.
   int32_t tokenizer_vocab_size = metadata[0];
+  if (tokenizer_vocab_size <= 0 ||
+      tokenizer_vocab_size > kMaxSupportedVocabSize) {
+    TK_LOG(
+        Error,
+        "Invalid vocab_size %d in tokenizer file (must be 1..%d)",
+        tokenizer_vocab_size,
+        kMaxSupportedVocabSize);
+    return Error::ParseFailure;
+  }
+  if (metadata[3] <= 0 || metadata[3] > kMaxTokenLengthBytes) {
+    TK_LOG(Error, "Invalid max_token_length %d in tokenizer file", metadata[3]);
+    return Error::ParseFailure;
+  }
+
   vocab_size_ = tokenizer_vocab_size;
   bos_tok_ = metadata[1];
   eos_tok_ = metadata[2];
@@ -76,7 +96,7 @@ Error Llama2cTokenizer::load(const std::string& tokenizer_path) {
 
   // read in the vocabulary
   for (int i = 0; i < vocab_size_; i++) {
-    if (fread(vocab_scores_.get() + i, sizeof(float), 1, file) != 1) {
+    if (fread(vocab_scores_.get() + i, sizeof(float), 1, file.get()) != 1) {
       // This is allowed, we just pad the rest of the vocab with <pad> strings
       std::string padding = "<pad>";
       vocab_[i] = new char[padding.length() + 1];
@@ -85,12 +105,21 @@ Error Llama2cTokenizer::load(const std::string& tokenizer_path) {
       continue;
     }
     int32_t len;
-    if (fread(&len, sizeof(int32_t), 1, file) != 1) {
+    if (fread(&len, sizeof(int32_t), 1, file.get()) != 1) {
       TK_LOG(Error, "Failed to read the length of the word at index %d", i);
       return Error::ParseFailure;
     }
+    if (len < 0 || len > kMaxTokenLengthBytes) {
+      TK_LOG(
+          Error,
+          "Invalid token length %d at index %d (max: %d)",
+          len,
+          i,
+          kMaxTokenLengthBytes);
+      return Error::ParseFailure;
+    }
     vocab_[i] = new char[len + 1];
-    if (fread(vocab_[i], len, 1, file) != 1) {
+    if (len > 0 && fread(vocab_[i], len, 1, file.get()) != 1) {
       TK_LOG(
           Error,
           "Failed to read the word, total length %d, index %d\n",
@@ -98,9 +127,9 @@ Error Llama2cTokenizer::load(const std::string& tokenizer_path) {
           i);
       return Error::ParseFailure;
     }
-    vocab_[i][len] = '\0'; // add the string terminating token
+    vocab_[i][len] = '\0';
+    max_token_length_ = std::max(max_token_length_, static_cast<uint32_t>(len));
   }
-  fclose(file);
 
   for (int32_t i = 0; i < vocab_size_; i++) {
     sorted_vocab_[i].str = vocab_[i];
@@ -113,8 +142,10 @@ Error Llama2cTokenizer::load(const std::string& tokenizer_path) {
 }
 
 Llama2cTokenizer::~Llama2cTokenizer() {
-  for (int i = 0; i < vocab_size_; i++) {
-    delete[] vocab_[i];
+  if (vocab_) {
+    for (int i = 0; i < vocab_size_; i++) {
+      delete[] vocab_[i];
+    }
   }
 }
 

--- a/test/test_llama2c_tokenizer.cpp
+++ b/test/test_llama2c_tokenizer.cpp
@@ -5,6 +5,14 @@
 #endif
 #include <gtest/gtest.h>
 #include <pytorch/tokenizers/llama2c_tokenizer.h>
+#include <cstdio>
+#include <cstdlib>
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace ::testing;
 
@@ -18,6 +26,24 @@ static inline std::string _get_resource_path(const std::string& name) {
       "test/resources/" + name);
 #else
   return std::getenv("RESOURCES_PATH") + std::string("/") + name;
+#endif
+}
+
+std::string make_temp_file() {
+#ifdef _WIN32
+  char tmp_dir[MAX_PATH];
+  char tmp_file[MAX_PATH];
+  GetTempPathA(MAX_PATH, tmp_dir);
+  GetTempFileNameA(tmp_dir, "tok", 0, tmp_file);
+  return std::string(tmp_file);
+#else
+  std::string tpl =
+      std::string(std::getenv("TMPDIR") ? std::getenv("TMPDIR") : "/tmp") +
+      "/tokenizer_test_XXXXXX";
+  int fd = mkstemp(&tpl[0]);
+  EXPECT_NE(fd, -1);
+  close(fd);
+  return tpl;
 #endif
 }
 
@@ -159,6 +185,104 @@ TEST_F(Llama2cTokenizerTest, SafeToDestruct) {
   // Safe to destruct uninitialized tokenizer.
   tokenizer_ = std::make_unique<Llama2cTokenizer>();
   tokenizer_.reset();
+}
+
+TEST_F(Llama2cTokenizerTest, DestructAfterFailedLoadIsSafe) {
+  // Issue #1: Destructor must not crash after failed load
+  Error res = tokenizer_->load("/nonexistent/path/tokenizer.bin");
+  EXPECT_NE(res, Error::Ok);
+  tokenizer_.reset(); // Must not crash
+}
+
+TEST_F(Llama2cTokenizerTest, DestructAfterCorruptFileIsSafe) {
+  // Destructor must not crash after load() returns ParseFailure
+  // with vocab_ partially populated.
+  std::string tmp_path = make_temp_file();
+  {
+    FILE* f = fopen(tmp_path.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    int32_t metadata[4] = {4, 1, 2, 10};
+    fwrite(metadata, sizeof(int32_t), 4, f);
+    float score = 1.0f;
+    fwrite(&score, sizeof(float), 1, f);
+    int32_t len = 5;
+    fwrite(&len, sizeof(int32_t), 1, f);
+    // Only write 2 of 5 bytes — fread of token content will fail
+    fwrite("ab", 2, 1, f);
+    fclose(f);
+  }
+  Error res = tokenizer_->load(tmp_path);
+  EXPECT_NE(res, Error::Ok);
+  tokenizer_.reset(); // Must not crash
+  std::remove(tmp_path.c_str());
+}
+
+TEST_F(Llama2cTokenizerTest, LoadRejectsNegativeVocabSize) {
+  // Issue #2: Reject invalid vocab_size from file
+  std::string tmp_path = make_temp_file();
+  {
+    FILE* f = fopen(tmp_path.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    int32_t metadata[4] = {-1, 1, 2, 10};
+    fwrite(metadata, sizeof(int32_t), 4, f);
+    fclose(f);
+  }
+  Error res = tokenizer_->load(tmp_path);
+  EXPECT_EQ(res, Error::ParseFailure);
+  tokenizer_.reset();
+  std::remove(tmp_path.c_str());
+}
+
+TEST_F(Llama2cTokenizerTest, LoadRejectsHugeVocabSize) {
+  // Issue #2: Reject impossibly large vocab_size
+  std::string tmp_path = make_temp_file();
+  {
+    FILE* f = fopen(tmp_path.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    int32_t metadata[4] = {2000000000, 1, 2, 10};
+    fwrite(metadata, sizeof(int32_t), 4, f);
+    fclose(f);
+  }
+  Error res = tokenizer_->load(tmp_path);
+  EXPECT_EQ(res, Error::ParseFailure);
+  tokenizer_.reset();
+  std::remove(tmp_path.c_str());
+}
+
+TEST_F(Llama2cTokenizerTest, LoadRejectsNegativeMaxTokenLength) {
+  // Issue #2: Reject negative max_token_length
+  std::string tmp_path = make_temp_file();
+  {
+    FILE* f = fopen(tmp_path.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    int32_t metadata[4] = {4, 1, 2, -5};
+    fwrite(metadata, sizeof(int32_t), 4, f);
+    fclose(f);
+  }
+  Error res = tokenizer_->load(tmp_path);
+  EXPECT_EQ(res, Error::ParseFailure);
+  tokenizer_.reset();
+  std::remove(tmp_path.c_str());
+}
+
+TEST_F(Llama2cTokenizerTest, LoadRejectsInvalidTokenLength) {
+  // Reject token length exceeding the hard safety limit (kMaxTokenLengthBytes)
+  std::string tmp_path = make_temp_file();
+  {
+    FILE* f = fopen(tmp_path.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    int32_t metadata[4] = {2, 0, 1, 10};
+    fwrite(metadata, sizeof(int32_t), 4, f);
+    float score = 1.0f;
+    fwrite(&score, sizeof(float), 1, f);
+    int32_t len = 1048577; // Exceeds kMaxTokenLengthBytes (1 MiB)
+    fwrite(&len, sizeof(int32_t), 1, f);
+    fclose(f);
+  }
+  Error res = tokenizer_->load(tmp_path);
+  EXPECT_EQ(res, Error::ParseFailure);
+  tokenizer_.reset();
+  std::remove(tmp_path.c_str());
 }
 
 } // namespace tokenizers

--- a/test/test_tiktoken.cpp
+++ b/test/test_tiktoken.cpp
@@ -261,4 +261,17 @@ TEST_F(TiktokenTest, LoadTiktokenFileWithBPEFile) {
 
   EXPECT_EQ(res, Error::ParseFailure);
 }
+
+TEST_F(TiktokenTest, EncodeEmptyStringDoesNotCrash) {
+  // Issue #3: Empty input to BPE must not cause unsigned underflow
+  Error res = tokenizer_->load(modelPath_.c_str());
+  EXPECT_EQ(res, Error::Ok);
+  // Empty string encode should return error or empty result, not crash
+  Result<std::vector<uint64_t>> out = tokenizer_->encode("", 0, 0);
+  // Either returns empty tokens or an error — both are acceptable
+  if (out.ok()) {
+    EXPECT_TRUE(out.get().empty());
+  }
+}
+
 } // namespace tokenizers


### PR DESCRIPTION
Summary:

Fix 3 critical memory safety issues discovered during code audit of xplat/pytorch/tokenizers/src:

1. **llama2c_tokenizer.cpp — Destructor UB on partial/failed load**: The destructor
   iterates `vocab_[0..vocab_size_)` calling `delete[]` on each entry. If `load()` fails
   partway, entries may be uninitialized pointers → heap corruption. Fix: guard destructor
   against null `vocab_` (and rely on `make_unique<char*[]>` value-initialization to nullptr).

2. **llama2c_tokenizer.cpp — Unvalidated vocab_size/len from untrusted file**: `vocab_size_`
   and per-token `len` are read from binary file without bounds checking. Malicious/corrupt
   files can cause enormous allocations or integer wrap. Fix: validate ranges before use.
   Also wrap FILE* in RAII unique_ptr to prevent resource leak on early return.

3. **bpe_tokenizer_base.cpp — Unsigned underflow on empty piece**: In `_byte_pair_merge()`,
   if `piece` is empty, `parts.size()` is 1 and `parts.size()-2` wraps to SIZE_MAX causing
   OOB access. Fix: early return on empty piece + use addition-based loop comparison.

All changes verified with buck2 build and new test cases covering:
- Destructor safety after failed/partial load
- Rejection of invalid metadata (negative/huge vocab_size, negative max_token_length, oversized token length)
- Empty string encoding safety

Builds on D104893053 (clang-tidy lint fixes) with deeper safety fixes.

Differential Revision: D104904876


