### PR TITLE
Update runtime version test for 1.3.0

### DIFF
--- a/test/test_python_bindings.py
+++ b/test/test_python_bindings.py
@@ -91,7 +91,7 @@ class TestPythonBindings(unittest.TestCase):
     def test_version(self):
         """Test that version is available"""
         self.assertTrue(hasattr(pytorch_tokenizers, "__version__"))
-        self.assertEqual(pytorch_tokenizers.__version__, "0.1.0")
+        self.assertEqual(pytorch_tokenizers.__version__, "1.3.0")
 
     def test_hf_tokenizer_encode_decode(self):
         """Test HFTokenizer with test_hf_tokenizer.json to encode/decode 'Hello world!'"""


### PR DESCRIPTION
Update the runtime __version__ smoke test expectation to match the 1.3.0 release metadata. The macOS wheel workflow failed because test_version still expected 0.1.0 after PR #190 updated pytorch_tokenizers.__version__ to 1.3.0.