### PR TITLE
Make HFWord::merge_all O(n log n)

### DIFF
--- a/include/pytorch/tokenizers/hf_tokenizer.h
+++ b/include/pytorch/tokenizers/hf_tokenizer.h
@@ -13,7 +13,9 @@
 #pragma once
 
 // Standard
+#include <cstdint>
 #include <string>
+#include <vector>
 
 // Local
 #include <nlohmann/json.hpp>
@@ -43,58 +45,6 @@ using MergeMap = std::unordered_map<
     std::pair<uint64_t, uint64_t>,
     PairHash>;
 
-// Utility function to build merge ranks map from merge rules
-template <typename TMergeMap>
-inline Result<TokenMap> build_merge_ranks_map(
-    const TMergeMap& merge_map,
-    const TokenMap& token_map) {
-  // Static assertions to verify TMergeMap has the expected key and value types
-  using KeyType = typename TMergeMap::key_type;
-  using ValueType = typename TMergeMap::mapped_type;
-
-  static_assert(
-      std::is_same_v<KeyType, std::pair<uint64_t, uint64_t>>,
-      "TMergeMap key type must be std::pair<uint64_t, uint64_t>");
-
-  static_assert(
-      std::is_same_v<ValueType, std::pair<uint64_t, uint64_t>>,
-      "TMergeMap value type must be std::pair<uint64_t, uint64_t>");
-
-  // Use a map to handle duplicates - keep the lowest rank (highest priority)
-  std::unordered_map<std::string, uint64_t> unique_merge_ranks;
-
-  for (const auto& [pair, rank_and_id] : merge_map) {
-    uint64_t first_id = pair.first;
-    uint64_t second_id = pair.second;
-    uint64_t rank = rank_and_id.first;
-
-    // Get the token strings for the pair
-    auto first_token = token_map.tryGetString(first_id);
-    auto second_token = token_map.tryGetString(second_id);
-
-    if (first_token && second_token) {
-      std::string merged_token =
-          std::string(*first_token) + std::string(*second_token);
-
-      // Keep the entry with the lowest rank (highest priority in BPE)
-      auto it = unique_merge_ranks.find(merged_token);
-      if (it == unique_merge_ranks.end() || rank < it->second) {
-        unique_merge_ranks[merged_token] = rank;
-      }
-    }
-  }
-
-  // Convert to vector for buildTokenMap
-  std::vector<std::pair<std::string, uint64_t>> merge_rank_pairs;
-  merge_rank_pairs.reserve(unique_merge_ranks.size());
-
-  for (const auto& [token, rank] : unique_merge_ranks) {
-    merge_rank_pairs.emplace_back(token, rank);
-  }
-
-  return build_token_map(std::move(merge_rank_pairs));
-}
-
 } // namespace detail
 
 // Simple Word structure to mimic Rust's Word behavior
@@ -111,62 +61,13 @@ struct HFWord {
     return tokens.size();
   }
 
-  // Apply all possible merges using the merge ranks
-  void merge_all(
-      const detail::TokenMap& merge_ranks,
-      const detail::TokenMap& token_map) {
-    while (tokens.size() > 1) {
-      std::optional<std::pair<size_t, uint32_t>> best_merge;
-
-      // Find the best merge (lowest rank) among adjacent token pairs
-      for (size_t i = 0; i < tokens.size() - 1; ++i) {
-        // Create the merged token string to look up its rank
-        auto first_token = token_map.tryGetString(tokens[i]);
-        auto second_token = token_map.tryGetString(tokens[i + 1]);
-
-        if (first_token && second_token) {
-          std::string merged_token =
-              std::string(*first_token) + std::string(*second_token);
-          auto rank = merge_ranks.tryGetInteger(merged_token);
-
-          if (rank && (!best_merge || *rank < best_merge->second)) {
-            best_merge = std::make_pair(i, static_cast<uint32_t>(*rank));
-          }
-        }
-      }
-
-      if (!best_merge) {
-        break; // No more merges possible
-      }
-
-      // Apply the best merge
-      size_t merge_idx = best_merge->first;
-
-      // Get the merged token ID
-      auto first_token = token_map.tryGetString(tokens[merge_idx]);
-      auto second_token = token_map.tryGetString(tokens[merge_idx + 1]);
-
-      if (first_token && second_token) {
-        std::string merged_token =
-            std::string(*first_token) + std::string(*second_token);
-        auto merged_id = token_map.tryGetInteger(merged_token);
-
-        if (merged_id) {
-          // Replace the two tokens with the merged token
-          tokens[merge_idx] = *merged_id;
-          byte_lengths[merge_idx] += byte_lengths[merge_idx + 1];
-
-          // Remove the second token
-          tokens.erase(tokens.begin() + merge_idx + 1);
-          byte_lengths.erase(byte_lengths.begin() + merge_idx + 1);
-        } else {
-          break; // Merged token not found in vocabulary
-        }
-      } else {
-        break; // Original tokens not found in vocabulary
-      }
-    }
-  }
+  // Apply all possible merges using the explicit (id, id) -> (rank, merged_id)
+  // merge map. Mirrors HuggingFace's Word::merge_all: an intrusive doubly
+  // linked list over the symbols plus a min-heap keyed on merge rank, giving
+  // O(n log n) instead of the naive rescan-all-pairs O(n^2). Lookups are by
+  // integer id pair, so there is no per-pair string allocation. Defined out of
+  // line in hf_tokenizer.cpp.
+  void merge_all(const detail::MergeMap& merge_map);
 };
 
 class HFTokenizer : public detail::BPETokenizerBase {
@@ -237,8 +138,6 @@ class HFTokenizer : public detail::BPETokenizerBase {
   TokenDecoder::Ptr _decoder;
 
   std::unique_ptr<detail::MergeMap> merge_map_;
-  std::optional<detail::TokenMap>
-      merge_ranks_; // Pre-computed merge ranks for BPE
   bool byte_fallback_ = false;
   bool unk_token_is_configured_ = false;
 };

--- a/src/hf_tokenizer.cpp
+++ b/src/hf_tokenizer.cpp
@@ -14,6 +14,7 @@
 #include <cinttypes>
 #include <filesystem>
 #include <fstream>
+#include <queue>
 #include <string>
 #include <vector>
 
@@ -24,6 +25,98 @@ namespace fs = std::filesystem;
 using json = nlohmann::json;
 
 namespace tokenizers {
+
+void HFWord::merge_all(const detail::MergeMap& merge_map) {
+  const size_t n = tokens.size();
+  if (n < 2) {
+    return;
+  }
+
+  std::vector<int64_t> prev(n), next(n);
+  std::vector<uint32_t> version(n, 0);
+  std::vector<bool> alive(n, true);
+  for (size_t i = 0; i < n; ++i) {
+    prev[i] = static_cast<int64_t>(i) - 1;
+    next[i] = (i + 1 < n) ? static_cast<int64_t>(i + 1) : -1;
+  }
+
+  // (rank, pos, version): lowest rank wins, ties broken by leftmost position to
+  // match left-to-right BPE order. `version` tracks only the left symbol; a
+  // candidate whose right neighbor changed is rejected below by recomputing the
+  // pair's rank and comparing to `c.rank`. That check relies on merge ranks
+  // being unique (they are merge indices), so a changed pair cannot
+  // coincidentally carry the same rank.
+  struct Candidate {
+    uint64_t rank;
+    int64_t pos;
+    uint32_t version;
+  };
+  struct Compare {
+    bool operator()(const Candidate& a, const Candidate& b) const {
+      if (a.rank != b.rank) {
+        return a.rank > b.rank;
+      }
+      return a.pos > b.pos;
+    }
+  };
+  std::priority_queue<Candidate, std::vector<Candidate>, Compare> heap;
+
+  auto push_pair = [&](int64_t i) {
+    if (i < 0 || next[i] < 0) {
+      return;
+    }
+    auto it = merge_map.find({tokens[i], tokens[next[i]]});
+    if (it != merge_map.end()) {
+      heap.push({it->second.first, i, version[i]});
+    }
+  };
+
+  for (size_t i = 0; i + 1 < n; ++i) {
+    push_pair(static_cast<int64_t>(i));
+  }
+
+  while (!heap.empty()) {
+    const Candidate c = heap.top();
+    heap.pop();
+    const int64_t i = c.pos;
+    if (!alive[i] || version[i] != c.version || next[i] < 0) {
+      continue; // stale entry
+    }
+    const int64_t j = next[i];
+    auto it = merge_map.find({tokens[i], tokens[j]});
+    if (it == merge_map.end() || it->second.first != c.rank) {
+      continue; // superseded by a different merge at this position
+    }
+
+    // Merge j into i.
+    tokens[i] = it->second.second;
+    byte_lengths[i] += byte_lengths[j];
+    alive[j] = false;
+    const int64_t jn = next[j];
+    next[i] = jn;
+    if (jn >= 0) {
+      prev[jn] = i;
+    }
+    ++version[i];
+
+    // Only the two adjacencies touching the merged symbol can change.
+    push_pair(prev[i]);
+    push_pair(i);
+  }
+
+  // Compact surviving symbols in list order (head is always index 0; it is only
+  // ever a left operand, never removed).
+  std::vector<uint64_t> merged_tokens;
+  std::vector<size_t> merged_byte_lengths;
+  merged_tokens.reserve(tokens.size());
+  merged_byte_lengths.reserve(byte_lengths.size());
+  for (int64_t i = 0; i != -1; i = next[i]) {
+    merged_tokens.push_back(tokens[i]);
+    merged_byte_lengths.push_back(byte_lengths[i]);
+  }
+  tokens = std::move(merged_tokens);
+  byte_lengths = std::move(merged_byte_lengths);
+}
 
 namespace {
 // Helper to extract token string from either string or object format
@@ -235,12 +328,12 @@ Result<std::vector<uint64_t>> HFTokenizer::byte_pair_encode_(
     }
   }
 
-  const detail::TokenMap& merge_ranks =
-      merge_ranks_ ? *merge_ranks_ : token_map;
-
+  // The HFTokenizer override of _byte_pair_merge merges via merge_map_ and
+  // ignores the ranks argument, so token_map is passed only to satisfy the
+  // signature.
   return _byte_pair_merge(
       piece,
-      merge_ranks,
+      token_map,
       [this, &piece, &token_map](uint64_t start, uint64_t stop) {
         std::string key = piece.substr(start, stop - start);
         const auto result = token_map.tryGetInteger(key);
@@ -259,7 +352,7 @@ Result<std::vector<uint64_t>> HFTokenizer::byte_pair_encode_(
 
 std::vector<uint64_t> HFTokenizer::_byte_pair_merge(
     const std::string& piece,
-    const detail::TokenMap& ranks,
+    const detail::TokenMap& /*ranks*/,
     std::function<uint64_t(uint64_t, uint64_t)> func) const {
   HFWord word;
   size_t i = 0;
@@ -306,8 +399,8 @@ std::vector<uint64_t> HFTokenizer::_byte_pair_merge(
     i += char_len;
   }
 
-  if (merge_ranks_ && token_map_) {
-    word.merge_all(*merge_ranks_, *token_map_);
+  if (merge_map_) {
+    word.merge_all(*merge_map_);
   }
   return word.tokens;
 }
@@ -460,13 +553,6 @@ Error HFTokenizer::parse_merges(const json& parsed_json) {
         }
       }
     }
-
-    auto merge_ranks_result =
-        detail::build_merge_ranks_map(*merge_map_, *token_map_);
-    if (!merge_ranks_result.ok()) {
-      return merge_ranks_result.error();
-    }
-    merge_ranks_.emplace(std::move(*merge_ranks_result));
   } catch (const std::exception& e) {
     TK_LOG(Error, "Could not parse merges: %s", e.what());
     return Error::LoadFailure;

--- a/src/hf_tokenizer.cpp
+++ b/src/hf_tokenizer.cpp
@@ -335,7 +335,7 @@ Result<std::vector<uint64_t>> HFTokenizer::byte_pair_encode_(
       piece,
       token_map,
       [this, &piece, &token_map](uint64_t start, uint64_t stop) {
-        std::string key = piece.substr(start, stop - start);
+        std::string_view key(piece.data() + start, stop - start);
         const auto result = token_map.tryGetInteger(key);
         if (result) {
           return *result;

--- a/test/test_hf_tokenizer.cpp
+++ b/test/test_hf_tokenizer.cpp
@@ -420,6 +420,71 @@ TEST(HFTokenizerTest, TestBPEMergeEncode) {
   // verify that merges are parsed and the tokenizer loads successfully.
 }
 
+// The following tests pin HFWord::merge_all behavior. They use null normalizer
+// and null pre-tokenizer so the whole input becomes a single BPE piece, which
+// lets us drive merge_all directly with hand-built vocab/merges.
+namespace {
+std::string merge_tokenizer_json(
+    const std::string& vocab,
+    const std::string& merges,
+    bool byte_fallback = false) {
+  return std::string(R"({"version":"1.0","model":{"type":"BPE","vocab":)") +
+      vocab + R"(,"merges":)" + merges +
+      R"(,"byte_fallback":)" + (byte_fallback ? "true" : "false") +
+      R"(},"normalizer":null,"pre_tokenizer":null,"added_tokens":[]})";
+}
+} // namespace
+
+// Cascading merge: a+b->ab enables ab+c->abc; a trailing symbol stays unmerged.
+TEST(HFTokenizerTest, MergeAllCascades) {
+  TempFile tmpfile(merge_tokenizer_json(
+      R"({"a":0,"b":1,"c":2,"ab":3,"abc":4})", R"(["a b","ab c"])"));
+  HFTokenizer tokenizer;
+  ASSERT_EQ(tokenizer.load(tmpfile.path()), Error::Ok);
+  auto result = tokenizer.encode("abcc", 0, 0);
+  ASSERT_TRUE(result.ok());
+  std::vector<uint64_t> expected = {4, 2}; // abc, c
+  EXPECT_EQ(result.get(), expected);
+}
+
+// The globally lowest-rank merge wins even when it is not the leftmost pair:
+// (y z) has rank 0, (x y) has rank 1, so y+z merges first.
+TEST(HFTokenizerTest, MergeAllPicksLowestRankNotLeftmost) {
+  TempFile tmpfile(merge_tokenizer_json(
+      R"({"x":0,"y":1,"z":2,"xy":3,"yz":4})", R"(["y z","x y"])"));
+  HFTokenizer tokenizer;
+  ASSERT_EQ(tokenizer.load(tmpfile.path()), Error::Ok);
+  auto result = tokenizer.encode("xyz", 0, 0);
+  ASSERT_TRUE(result.ok());
+  std::vector<uint64_t> expected = {0, 4}; // x, yz
+  EXPECT_EQ(result.get(), expected);
+}
+
+// Overlapping equal-rank candidates: "aaa" with a+a->aa must merge the leftmost
+// pair first (-> [aa, a]), exercising stale-entry invalidation of the overlap.
+TEST(HFTokenizerTest, MergeAllLeftmostOnOverlap) {
+  TempFile tmpfile(
+      merge_tokenizer_json(R"({"a":0,"aa":1})", R"(["a a"])"));
+  HFTokenizer tokenizer;
+  ASSERT_EQ(tokenizer.load(tmpfile.path()), Error::Ok);
+  auto result = tokenizer.encode("aaa", 0, 0);
+  ASSERT_TRUE(result.ok());
+  std::vector<uint64_t> expected = {1, 0}; // aa, a
+  EXPECT_EQ(result.get(), expected);
+}
+
+// Merge over byte-fallback symbols: 'c' falls back to <0x63>, then a+b->ab.
+TEST(HFTokenizerTest, MergeAllWithByteFallback) {
+  TempFile tmpfile(merge_tokenizer_json(
+      R"({"a":0,"b":1,"ab":2,"<0x63>":3})", R"(["a b"])", /*byte_fallback=*/true));
+  HFTokenizer tokenizer;
+  ASSERT_EQ(tokenizer.load(tmpfile.path()), Error::Ok);
+  auto result = tokenizer.encode("abc", 0, 0);
+  ASSERT_TRUE(result.ok());
+  std::vector<uint64_t> expected = {2, 3}; // ab, <0x63>
+  EXPECT_EQ(result.get(), expected);
+}
+
 TEST(HFTokenizerTest, TestByteFallback) {
   // Create a minimal tokenizer with byte fallback enabled
   // Vocab: "a": 0, "<0x62>": 1 (for 'b')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #196
* __->__ #195
* #194

The BPE merge rescanned every adjacent pair on each iteration, concatenating
token strings and hashing them, plus an O(n) vector erase per merge -- O(n^2) in
the piece length, which for Gemma is the whole prompt (its normalizer turns
spaces into the word marker before the space-splitter runs, so pre-tokenization
yields a single piece).

Replace it with HuggingFace's algorithm: an intrusive doubly linked list over
the symbols plus a min-heap keyed on merge rank, looking merges up by integer
(id, id) pair in merge_map_ instead of by concatenated strings. The ranks in
merge_map_ are the same merge-index ranks the old code used, so merge decisions
(lowest rank, leftmost on tie) are unchanged. merge_map_ now drives the encode
path directly, so the redundant string-keyed merge_ranks_ map, its load-time
construction, and the now-unused build_merge_ranks_map helper are removed.

New tests pin the behavior: cascading merges, lowest-rank-wins on a non-leftmost
pair, leftmost-first on overlapping equal-rank pairs, and merging over
byte-fallback symbols.

Latency, Gemma-4-31B tokenizer, Release, mean of 5 reps (before -> after):
```
  vector          chars     ids    before_ms    after_ms   speedup
  prose_0.5k       2240     491        241.4        1.64      147x
  code_1k          4514    1891        789.2        2.63      300x
  dialogue_1.5k    6720    1345       2212.5        5.05      438x
  prose_2k         8946    1450       3905.4        7.15      546x
  prose_8k        49416    8005     123504.8       53.08     2327x
```
Tests: all 13 tokenizers unit tests pass (including the four new merge tests).

Authored with assistance from Claude Code.