### PR TITLE
Make ReplaceNormalizer::normalize O(N) (single forward pass)

### DIFF
--- a/benchmark/hf_tokenizer_encode_latency.cpp
+++ b/benchmark/hf_tokenizer_encode_latency.cpp
@@ -53,6 +53,14 @@ std::vector<Vector> vectors() {
        "In the beginning the system parsed every token sequentially, which made "
        "long prompts increasingly expensive to process as length grew larger. ",
        348},
+      {"prose_16k",
+       "In the beginning the system parsed every token sequentially, which made "
+       "long prompts increasingly expensive to process as length grew larger. ",
+       696},
+      {"prose_64k",
+       "In the beginning the system parsed every token sequentially, which made "
+       "long prompts increasingly expensive to process as length grew larger. ",
+       2784},
   };
 }
 

--- a/include/pytorch/tokenizers/regex.h
+++ b/include/pytorch/tokenizers/regex.h
@@ -38,8 +38,12 @@ class IRegex {
   /**
    * @brief Find all non-overlapping matches in the input string.
    *
+   * Matches are returned in left-to-right order with non-overlapping,
+   * non-decreasing [start, end) byte offsets. Callers (e.g. ReplaceNormalizer)
+   * rely on this ordering.
+   *
    * @param text The input string to search.
-   * @return A vector of strings containing all matched substrings.
+   * @return A vector of Match ranges, one per match.
    */
   virtual std::vector<Match> find_all(const std::string& text) const = 0;
 

--- a/src/normalizer.cpp
+++ b/src/normalizer.cpp
@@ -16,6 +16,7 @@
 
 // Standard
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -124,14 +125,36 @@ std::string ReplaceNormalizer::normalize(const std::string& input) const {
   if (!regex_)
     return input;
 
-  std::string result = input;
-  auto matches = regex_->find_all(result);
-
-  // Process matches in reverse order to avoid offset issues
-  for (auto it = matches.rbegin(); it != matches.rend(); ++it) {
-    const auto& match = *it;
-    result.replace(match.start, match.end - match.start, content_);
+  auto matches = regex_->find_all(input);
+  if (matches.empty()) {
+    return input;
   }
+
+  // Single forward pass: copy each unmatched span then the replacement. The
+  // previous code mutated the string in place once per match, shifting the
+  // tail each time (O(N^2)); this is O(N) with a single allocation. Relies on
+  // find_all returning matches in left-to-right order with non-overlapping,
+  // non-decreasing offsets (see IRegex::find_all).
+  std::string result;
+  // Exact output size: each match replaces [start, end) with content_. Computed
+  // by addition only (no multiplication) so it cannot overflow before the
+  // matches themselves would.
+  size_t out_size = input.size();
+  for (const auto& match : matches) {
+    out_size += content_.size();
+    out_size -= match.end - match.start;
+  }
+  result.reserve(out_size);
+  size_t prev_end = 0;
+  for (const auto& match : matches) {
+    // Guard the find_all ordering contract so a misbehaving regex wrapper
+    // fails here rather than underflowing match.start - prev_end.
+    assert(match.start >= prev_end && match.end >= match.start);
+    result.append(input, prev_end, match.start - prev_end);
+    result.append(content_);
+    prev_end = match.end;
+  }
+  result.append(input, prev_end, input.size() - prev_end);
 
   return result;
 }

--- a/test/test_normalizer.cpp
+++ b/test/test_normalizer.cpp
@@ -39,6 +39,38 @@ TEST(NormalizerTest, ReplaceNormalizerMultipleMatches) {
   EXPECT_EQ(result, expected);
 }
 
+TEST(NormalizerTest, ReplaceNormalizerEmptyContent) {
+  // Empty replacement deletes every match.
+  ReplaceNormalizer normalizer("a", "");
+  EXPECT_EQ(normalizer.normalize("banana"), "bnn");
+}
+
+TEST(NormalizerTest, ReplaceNormalizerAtBoundaries) {
+  // Matches at the very start and very end of the input.
+  ReplaceNormalizer normalizer(" ", "_");
+  EXPECT_EQ(normalizer.normalize(" a b "), "_a_b_");
+}
+
+TEST(NormalizerTest, ReplaceNormalizerConsecutiveMatches) {
+  // Adjacent matches with a multi-byte (3-byte) replacement.
+  ReplaceNormalizer normalizer(" ", "▁");
+  EXPECT_EQ(normalizer.normalize("a   b"), "a▁▁▁b");
+}
+
+TEST(NormalizerTest, ReplaceNormalizerVariableSpanMultiCharContent) {
+  // Variable-length matched spans with a multi-char replacement, including
+  // spans at both boundaries.
+  ReplaceNormalizer normalizer("\\s+", "__");
+  EXPECT_EQ(normalizer.normalize(" a  b "), "__a__b__");
+}
+
+TEST(NormalizerTest, ReplaceNormalizerZeroWidthMatch) {
+  // Zero-width (lookahead) match: insert content before each 'b' without
+  // consuming input. Exercises match.start == match.end in the forward pass.
+  ReplaceNormalizer normalizer("(?=b)", "X");
+  EXPECT_EQ(normalizer.normalize("abc"), "aXbc");
+}
+
 TEST(NormalizerTest, PrependNormalizerBasic) {
   // Test basic prepending
   PrependNormalizer normalizer("_");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #196
* #195
* #194

normalize() collected all matches then mutated the string in place once per
match in reverse; each replace shifts the entire tail, so replacing the spaces
in a long prompt is O(N^2). For Gemma every space becomes the word marker, so
this ran on the full prompt. Build the result in one forward pass instead: copy
each unmatched span then the replacement, with a single reserved allocation.
This relies on find_all returning ordered, non-overlapping matches, now stated
in its contract and guarded by a debug assertion.

This is the secondary quadratic; the dominant one was the BPE merge. Output is
unchanged (same spans replaced with the same content). New tests cover empty
replacement content, matches at the input boundaries, consecutive matches,
variable-length spans with multi-byte content, and zero-width (lookahead)
matches.

Introduces the larger prose_16k/prose_64k benchmark vectors here (now fast
enough to run with both fixes in place) to show this change. Gemma-4-31B
tokenizer, Release, mean of 8 reps; merge_only = with the BPE-merge change but
the old reverse-replace normalizer:
```
  vector        chars     ids   merge_only_ms   merge+norm_ms   saving
  prose_2k       8946    1450            7.09            7.13      ~0%
  prose_8k      49416    8005           47.15           44.22       6%
  prose_16k     98832   16009          124.72          101.80      18%
  prose_64k    395328   64033          946.65          602.10      36%
```
Below ~16k tokens the saving is within a few percent (run-to-run noise at the
smaller sizes); at 64k it is ~345 ms.

Tests: all 13 tokenizers unit tests pass (incl. the new normalizer edge cases).

Authored with assistance from Claude Code.