### PR TITLE
ByteLevel: honor use_regex=false (match HuggingFace tokenization)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -17,6 +17,7 @@ runtime.cxx_library(
         "@EXECUTORCH_CLIENTS",
     ],
     exported_deps = [
+        "fbsource//third-party/nlohmann-json:nlohmann-json",
         "fbsource//third-party/re2:re2",
     ],
     exported_external_deps = [
@@ -140,7 +141,6 @@ runtime.cxx_library(
         "@EXECUTORCH_CLIENTS",
     ],
     deps = [
-        "fbsource//third-party/nlohmann-json:nlohmann-json",
         ":regex",
     ],
     exported_deps = [

--- a/include/pytorch/tokenizers/pre_tokenizer.h
+++ b/include/pytorch/tokenizers/pre_tokenizer.h
@@ -105,6 +105,16 @@ class PreTokenizerConfig {
   CONFIG_MEMBER(bool, add_prefix_space)
 
   /**
+   * Used by: ByteLevelPreTokenizer
+   *
+   * When false, ByteLevel does not split the input with the GPT2 regex; the
+   * whole input piece is byte-encoded as a single piece (matches HF's ByteLevel
+   * use_regex=false). Defaults to true to preserve behavior for configs that
+   * omit it.
+   */
+  CONFIG_MEMBER(bool, use_regex)
+
+  /**
    * Used by RegexPreTokenizer
    */
   CONFIG_MEMBER(bool, is_delimiter)
@@ -227,10 +237,14 @@ class ByteLevelPreTokenizer : public PreTokenizer {
    * @param add_prefix_space: Whether to add a leading space to the first word
    * @param pattern: A user-supplied regex to use for token splitting. If not
    *    provided, it use the standard GPT2 pattern.
+   * @param use_regex: Whether to split the input with the regex. If false, the
+   *    whole input piece is byte-encoded as a single piece without splitting
+   *    (matches HF's ByteLevel use_regex=false).
    */
   ByteLevelPreTokenizer(
       bool add_prefix_space = true,
-      const std::string& pattern = "");
+      const std::string& pattern = "",
+      bool use_regex = true);
   explicit ByteLevelPreTokenizer(const std::string& pattern)
       : ByteLevelPreTokenizer(true, pattern) {}
 
@@ -241,6 +255,7 @@ class ByteLevelPreTokenizer : public PreTokenizer {
  private:
   const std::string pattern_;
   const bool add_prefix_space_;
+  const bool use_regex_;
 
 }; // end class ByteLevelPreTokenizer
 

--- a/src/pre_tokenizer.cpp
+++ b/src/pre_tokenizer.cpp
@@ -71,17 +71,14 @@ PreTokenizer::Ptr PreTokenizerConfig::create() const {
     return PreTokenizer::Ptr(new DigitsPreTokenizer());
   }
   if (type == "ByteLevel") {
-    if (add_prefix_space && pattern) {
-      return PreTokenizer::Ptr(
-          new ByteLevelPreTokenizer(*add_prefix_space, *pattern));
-    }
-    if (add_prefix_space) {
-      return PreTokenizer::Ptr(new ByteLevelPreTokenizer(*add_prefix_space));
-    }
+    const bool prefix_space = add_prefix_space.value_or(true);
+    const bool regex = use_regex.value_or(true);
     if (pattern) {
-      return PreTokenizer::Ptr(new ByteLevelPreTokenizer(*pattern));
+      return PreTokenizer::Ptr(
+          new ByteLevelPreTokenizer(prefix_space, *pattern, regex));
     }
-    return PreTokenizer::Ptr(new ByteLevelPreTokenizer());
+    return PreTokenizer::Ptr(
+        new ByteLevelPreTokenizer(prefix_space, "", regex));
   }
   if (type == "Sequence") {
     if (!pretokenizers || pretokenizers->empty()) {
@@ -136,7 +133,11 @@ PreTokenizerConfig& PreTokenizerConfig::parse_json(const json& json_config) {
       add_prefix_space = json_config.at("add_prefix_space");
     } catch (json::out_of_range&) {
     }
-    // TODO: trim_offsets, use_regex
+    try {
+      use_regex = json_config.at("use_regex");
+    } catch (json::out_of_range&) {
+    }
+    // TODO: trim_offsets
   } else if (type == "Sequence") {
     pretokenizers = std::vector<PreTokenizerConfig>();
     for (const auto& entry : json_config.at("pretokenizers")) {
@@ -265,6 +266,21 @@ namespace {
 constexpr char GPT2_EXPR[] =
     R"('s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+)";
 
+// Byte-encode the whole input as a single piece, matching the byte-level
+// alphabet mapping that unicode_regex_split applies via
+// unicode_byte_encoding_process. Used when use_regex is false so the input is
+// not split by the GPT2 regex.
+std::string byte_encode(const std::string& input) {
+  std::string result;
+  // Each input byte maps to a byte-level codepoint that is at most 2 bytes in
+  // UTF-8, so reserve up front to avoid repeated reallocations on the hot path.
+  result.reserve(input.size() * 2);
+  for (const unsigned char byte : input) {
+    result += unicode_byte_to_utf8(byte);
+  }
+  return result;
+}
+
 } // namespace
 
 //////////////////
@@ -273,9 +289,11 @@ constexpr char GPT2_EXPR[] =
 
 ByteLevelPreTokenizer::ByteLevelPreTokenizer(
     bool add_prefix_space,
-    const std::string& pattern)
+    const std::string& pattern,
+    bool use_regex)
     : pattern_(pattern.empty() ? GPT2_EXPR : pattern),
-      add_prefix_space_(add_prefix_space) {}
+      add_prefix_space_(add_prefix_space),
+      use_regex_(use_regex) {}
 
 std::vector<std::string> ByteLevelPreTokenizer::pre_tokenize(
     const std::string& input) const {
@@ -284,6 +302,12 @@ std::vector<std::string> ByteLevelPreTokenizer::pre_tokenize(
   if (add_prefix_space_ && !formatted_input.empty() &&
       formatted_input[0] != ' ') {
     formatted_input.insert(formatted_input.begin(), ' ');
+  }
+
+  // When use_regex is false, do not split with the GPT2 regex; byte-encode the
+  // whole input as a single piece (matches HF ByteLevel use_regex=false).
+  if (!use_regex_) {
+    return {byte_encode(formatted_input)};
   }
 
   return unicode_regex_split(formatted_input, {pattern_});

--- a/test/test_hf_tokenizer.cpp
+++ b/test/test_hf_tokenizer.cpp
@@ -10,6 +10,8 @@
 #include <gtest/gtest.h>
 #include <pytorch/tokenizers/hf_tokenizer.h>
 
+#include <array>
+#include <cstdio>
 #include <fstream>
 
 namespace tokenizers {
@@ -581,6 +583,68 @@ TEST(HFTokenizerTest, TestEmptyAndUnknown) {
   EXPECT_TRUE(unk_result.ok());
   std::vector<uint64_t> expected_unk = {1}; // [UNK]
   EXPECT_EQ(unk_result.get(), expected_unk);
+}
+
+// Strict id-golden for a use_regex=false ByteLevel config, proving the encode
+// path now matches HuggingFace's use_regex=false semantics (and that the
+// historical use_regex=true path is unchanged). The byte-level alphabet maps
+// the printable ASCII bytes 'a' (0x61), '(' (0x28) and 'b' (0x62) to
+// themselves, so the vocab can use the raw characters. The merges combine
+// a + ( -> "a(" then a( + b -> "a(b".
+TEST(HFTokenizerTest, TestByteLevelUseRegexFalseEncode) {
+  const char* json_template = R"({
+    "version": "1.0",
+    "model": {
+      "type": "BPE",
+      "vocab": {
+        "a": 0,
+        "(": 1,
+        "b": 2,
+        "a(": 3,
+        "a(b": 4
+      },
+      "merges": [
+        "a (",
+        "a( b"
+      ]
+    },
+    "normalizer": null,
+    "pre_tokenizer": {
+      "type": "ByteLevel",
+      "add_prefix_space": false,
+      "trim_offsets": false,
+      "use_regex": %s
+    },
+    "added_tokens": []
+  })";
+
+  // use_regex=false: ByteLevel keeps "a(b" whole, so the merges apply and the
+  // input collapses to the single token "a(b" (id 4) -- matching HF.
+  {
+    std::array<char, 1024> buf{};
+    std::snprintf(buf.data(), buf.size(), json_template, "false");
+    TempFile tmpfile(buf.data());
+    HFTokenizer tokenizer;
+    ASSERT_EQ(tokenizer.load(tmpfile.path()), Error::Ok);
+    auto result = tokenizer.encode("a(b", /*bos=*/0, /*eos=*/0);
+    ASSERT_TRUE(result.ok());
+    std::vector<uint64_t> expected = {4};
+    EXPECT_EQ(result.get(), expected);
+  }
+
+  // use_regex=true: ByteLevel splits "a(b" into "a", "(", "b" via the GPT2
+  // regex, so the merges cannot cross piece boundaries and we get three tokens.
+  {
+    std::array<char, 1024> buf{};
+    std::snprintf(buf.data(), buf.size(), json_template, "true");
+    TempFile tmpfile(buf.data());
+    HFTokenizer tokenizer;
+    ASSERT_EQ(tokenizer.load(tmpfile.path()), Error::Ok);
+    auto result = tokenizer.encode("a(b", /*bos=*/0, /*eos=*/0);
+    ASSERT_TRUE(result.ok());
+    std::vector<uint64_t> expected = {0, 1, 2};
+    EXPECT_EQ(result.get(), expected);
+  }
 }
 
 TEST(HFTokenizerTest, TestUnkTokenConfiguration) {

--- a/test/test_pre_tokenizer.cpp
+++ b/test/test_pre_tokenizer.cpp
@@ -93,6 +93,25 @@ TEST_F(ByteLevelPreTokenizerTest, PreTokenizeCustomRegex) {
   assert_split_match(ptok, "Hello World", {"Hell", "o", "ĠW", "o", "rld"});
 }
 
+TEST_F(ByteLevelPreTokenizerTest, PreTokenizeNoRegexSinglePiece) {
+  // use_regex=false: the whole input is byte-encoded as ONE piece, with no
+  // GPT2 split. Space byte (0x20) maps to the byte-level char Ġ.
+  ByteLevelPreTokenizer ptok(
+      /*add_prefix_space=*/false, /*pattern=*/"", /*use_regex=*/false);
+  assert_split_match(ptok, "Hello World", {"HelloĠWorld"});
+  // Punctuation glued to a following letter run stays in one piece (the
+  // divergence this fix targets); the default path would split "(" off.
+  assert_split_match(ptok, "foo(bar", {"foo(bar"});
+}
+
+TEST_F(ByteLevelPreTokenizerTest, PreTokenizeNoRegexWithPrefix) {
+  // The prefix space is added first, then the whole thing is one byte-encoded
+  // piece.
+  ByteLevelPreTokenizer ptok(
+      /*add_prefix_space=*/true, /*pattern=*/"", /*use_regex=*/false);
+  assert_split_match(ptok, "Hello World", {"ĠHelloĠWorld"});
+}
+
 // SequencePreTokenizer ////////////////////////////////////////////////////////
 class SequencePreTokenizerTest : public ::testing::Test {};
 
@@ -118,6 +137,20 @@ TEST_F(SequencePreTokenizerTest, PreTokenizeDigitAndByteLevel) {
        "."});
 }
 
+TEST_F(SequencePreTokenizerTest, PreTokenizeSplitThenByteLevelNoRegex) {
+  // Mirror the production model: Sequence[Split(GPT2-like regex), ByteLevel(
+  // use_regex=false)]. Split glues a leading punctuation char to the following
+  // letter run ("foo(bar" -> ["foo", "(bar"]); with use_regex=false ByteLevel
+  // keeps "(bar" whole. The default ByteLevel would further split it into
+  // "(" and "bar", which is the bug this fix corrects.
+  PreTokenizer::Ptr split = std::make_shared<RegexPreTokenizer>(
+      R"((?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+)");
+  PreTokenizer::Ptr byte_no_regex = std::make_shared<ByteLevelPreTokenizer>(
+      /*add_prefix_space=*/false, /*pattern=*/"", /*use_regex=*/false);
+  SequencePreTokenizer ptok({split, byte_no_regex});
+  assert_split_match(ptok, "foo(bar", {"foo", "(bar"});
+}
+
 // PreTokenizerConfig //////////////////////////////////////////////////////////
 //
 // NOTE: When adding a new pre-tokenizer or changing arguments, add it to these
@@ -140,6 +173,11 @@ TEST_F(PreTokenizerConfigTest, AllTypesSuccess) {
   PreTokenizerConfig("ByteLevel")
       .set_add_prefix_space(false)
       .set_pattern(R"(o)")
+      .create();
+  PreTokenizerConfig("ByteLevel").set_use_regex(false).create();
+  PreTokenizerConfig("ByteLevel")
+      .set_add_prefix_space(false)
+      .set_use_regex(false)
       .create();
 
   // Sequence
@@ -203,6 +241,41 @@ TEST_F(PreTokenizerConfigTest, ParseJson) {
        "Ġ",
        "5",
        "."});
+}
+
+TEST_F(PreTokenizerConfigTest, ByteLevelUseRegexParsing) {
+  // use_regex=false -> the whole input is one byte-encoded piece.
+  const auto no_regex = PreTokenizerConfig()
+                            .parse_json(
+                                json{
+                                    {"type", "ByteLevel"},
+                                    {"add_prefix_space", false},
+                                    {"use_regex", false},
+                                })
+                            .create();
+  assert_split_match(*no_regex, "Hello World", {"HelloĠWorld"});
+
+  // use_regex=true -> GPT2 split (the historical default behavior).
+  const auto with_regex = PreTokenizerConfig()
+                              .parse_json(
+                                  json{
+                                      {"type", "ByteLevel"},
+                                      {"add_prefix_space", false},
+                                      {"use_regex", true},
+                                  })
+                              .create();
+  assert_split_match(*with_regex, "Hello World", {"Hello", "ĠWorld"});
+
+  // use_regex omitted -> defaults to true, so behavior is unchanged for configs
+  // that do not set the field.
+  const auto omitted = PreTokenizerConfig()
+                           .parse_json(
+                               json{
+                                   {"type", "ByteLevel"},
+                                   {"add_prefix_space", false},
+                               })
+                           .create();
+  assert_split_match(*omitted, "Hello World", {"Hello", "ĠWorld"});
 }
 
 TEST_F(PreTokenizerConfigTest, ParseJsonOptionalKey) {
@@ -467,6 +540,48 @@ TEST_F(RegexCacheTest, ByteLevelDeterministicAndThreadSafe) {
     th.join();
   }
   EXPECT_EQ(0, mismatches.load());
+}
+
+TEST_F(RegexCacheTest, ByteLevelNoRegexSinglePieceEqualsByteEncoding) {
+  // With use_regex=false the input is never split: each item yields exactly one
+  // piece. That piece must equal the byte-encoding of the whole input, which is
+  // the concatenation of the default (GPT2-split) path's byte-encoded pieces
+  // (splitting happens on codepoint boundaries, so concatenating the encoded
+  // pieces reconstructs the encoding of the whole input). This pins the new
+  // behavior without hardcoding the byte-level alphabet.
+  ByteLevelPreTokenizer no_regex(
+      /*add_prefix_space=*/false, /*pattern=*/"", /*use_regex=*/false);
+  ByteLevelPreTokenizer with_regex(/*add_prefix_space=*/false);
+
+  const std::vector<std::string> corpus = {
+      "Hello World",
+      "  leading and   multiple   spaces  ",
+      "tabs\t\tand\nnewlines\r\n",
+      "code: { return x; }   // trailing   ",
+      "foo(bar",
+      "a(b",
+      "(the",
+      "hi_there",
+      "next:\n",
+      "a\xC2\x85"
+      "b", // U+0085 NEL
+      "a\xE2\x80\x80\xE2\x80\x8A"
+      "b", // U+2000 .. U+200A
+      "a\xE2\x80\x8B"
+      "b", // U+200B ZERO WIDTH SPACE (non-ws)
+      "caf\xC3\xA9 \xE4\xBD\xA0\xE5\xA5\xBD",
+      "history: i0:<1326-617-1617> next:",
+  };
+
+  for (const auto& s : corpus) {
+    const auto one_piece = no_regex.pre_tokenize(s);
+    ASSERT_EQ(one_piece.size(), 1u) << "input: " << s;
+    std::string concat;
+    for (const auto& p : with_regex.pre_tokenize(s)) {
+      concat += p;
+    }
+    EXPECT_EQ(one_piece[0], concat) << "input: " << s;
+  }
 }
 
 TEST_F(PreTokenizerConfigTest, SplitWithInvertTrue) {


### PR DESCRIPTION
Summary:
The `ByteLevel` pre-tokenizer ignored the `use_regex` field in `tokenizer.json` and always split each piece with the GPT2 regex. HuggingFace's `ByteLevel` supports `use_regex=false`, where the input is byte-encoded without any regex split. Models trained with `ByteLevel(use_regex=false)` — e.g. model `2119730608`, whose `pre_tokenizer` is `Sequence[Split, ByteLevel(use_regex=false)]` — were therefore tokenized differently at serving time than at training time: a real train/serve skew that changes the emitted token-ids.

This is a correctness fix:

- Parse `use_regex` from the `ByteLevel` config (`PreTokenizerConfig`), defaulting to `true` so configs that omit the field are completely unchanged.
- Thread it into `ByteLevelPreTokenizer`; when `false`, `pre_tokenize` byte-encodes the whole (optionally prefix-spaced) input as a single piece and skips the GPT2 regex entirely.

For `use_regex=false` models the token-ids now match HuggingFace exactly; the default (`true`) keeps every other model bit-identical.

This is upstreamable to the OSS `pytorch/tokenizers` and aligns with HF `ByteLevel` semantics; we intend to send it upstream.

Reviewed By: jinhohwang-meta

Differential Revision: D108656350


