### PR TITLE
Fix string integer map offset sizing

### DIFF
--- a/include/pytorch/tokenizers/string_integer_map.h
+++ b/include/pytorch/tokenizers/string_integer_map.h
@@ -270,12 +270,16 @@ Error StringIntegerMap<TStringHash, TIntegerHash, TAllocator>::init(
 
   integer_ = VariableSizedInteger<std::uint64_t>(largest_integer);
   string_size_ = VariableSizedInteger<std::size_t>(largest_string_size);
-  string_offset_ = VariableSizedInteger<std::size_t>(total_string_size);
 
   const auto string_element_data_size =
       ((integer_.getByteCount() + string_size_.getByteCount() + 1) *
        map.size()) +
       total_string_size;
+
+  // string_offset_ stores byte offsets into string_element_data_, including
+  // each element's header bytes, not offsets into only the string payload.
+  string_offset_ = VariableSizedInteger<std::size_t>(string_element_data_size);
+
   const auto integer_element_size = integer_.getByteCount() +
       string_offset_.getByteCount() + string_size_.getByteCount();
   const auto integer_element_data_size = integer_element_size * map.size();

--- a/test/test_string_integer_map.cpp
+++ b/test/test_string_integer_map.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #if defined(__APPLE__) || defined(WIN32) || defined(__linux__)
 #define TEST_MEMORY_COMPARISON 1
@@ -271,6 +272,20 @@ struct FixedHash {
   }
 };
 
+struct OffsetBoundaryHash {
+  std::size_t operator()(const std::string_view& str) const {
+    if (str.empty()) {
+      return 0;
+    }
+
+    return static_cast<unsigned char>(str.front()) - 1;
+  }
+
+  std::size_t operator()(std::uint64_t value) const {
+    return static_cast<std::size_t>(value);
+  }
+};
+
 template <typename THash>
 class StringIntegerMapHashTest : public Test {
  public:
@@ -360,4 +375,27 @@ TEST(StringIntegerMapCreateTest, DetectsDuplicateRanks) {
   auto result = StringIntegerMap<>::create(pairs);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.error(), Error::ParseFailure);
+}
+
+TEST(StringIntegerMapCreateTest, HandlesStringElementOffsetsBeyondPayloadSize) {
+  using Container = typename StringIntegerMapTypeBuilder<>::WithIntegerHash<
+      OffsetBoundaryHash>::template WithStringHash<OffsetBoundaryHash>::Map;
+
+  std::vector<std::pair<std::string, std::uint64_t>> source;
+  source.reserve(70);
+  for (std::uint64_t i = 0; i < 70; ++i) {
+    source.emplace_back(std::string(1, static_cast<char>(i + 1)), i);
+  }
+
+  auto map_result = Container::create(source);
+  ASSERT_TRUE(map_result.ok());
+  auto map = std::move(*map_result);
+
+  for (const auto& [expected_string, integer] : source) {
+    EXPECT_THAT(
+        map.tryGetString(integer), Optional(std::string_view(expected_string)))
+        << integer;
+    EXPECT_THAT(map.tryGetInteger(expected_string), Optional(integer))
+        << integer;
+  }
 }


### PR DESCRIPTION
StringIntegerMap packs string entries into string_element_data_ as header bytes followed by string payload. The integer-to-string path stores a string_offset_ field for each integer entry, and that field is a byte offset into the full string_element_data_ buffer.

string_offset_ was sized from total_string_size, which counts only payload bytes. When payload size and full element data size land in different 256^k brackets, higher offsets truncate and tryGetString(id) can silently return the wrong string.

Compute string_element_data_size before sizing string_offset_, then size string_offset_ from that full buffer size. This matches the actual value written to the field and is a safe upper bound because real element offsets are less than string_element_data_size.

I also checked the sibling variable-width fields: integer_ is sized from largest_integer, string_size_ from largest_string_size, and element_offset_ from max(string_element_data_size, integer_element_data_size). A grep found no other VariableSizedInteger structure outside this map.

Test Plan:

- Temporarily restored the old total_string_size sizing and confirmed StringIntegerMapCreateTest.HandlesStringElementOffsetsBeyondPayloadSize fails for entries past the 255-byte offset boundary.

- ./build-regression-gcc/test_string_integer_map --gtest_filter=StringIntegerMapCreateTest.HandlesStringElementOffsetsBeyondPayloadSize

- ctest --test-dir build-gcc --output-on-failure

- ctest --test-dir build-clang --output-on-failure
