### PR TITLE
Add OSS buck nlohmann_json header-only target

### DIFF
--- a/third-party/targets.bzl
+++ b/third-party/targets.bzl
@@ -3,6 +3,13 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 def define_common_targets():
     if runtime.is_oss:
         runtime.cxx_library(
+            name = "nlohmann_json",
+            _is_external_target = True,
+            public_include_directories = ["json/single_include"],
+            visibility = ["PUBLIC"],
+        )
+
+        runtime.cxx_library(
             name = "abseil",
             srcs = glob(
                 ["abseil-cpp/absl/**/*.cc"],


### PR DESCRIPTION
The headers target now exports fbsource//third-party/nlohmann-json, which maps to shim_et//third-party/nlohmann-json in ExecuTorch's OSS buck2 build. Provide a header-only nlohmann_json target sourced from the json submodule's single_include directory so the shim can alias to it, mirroring the existing re2/abseil OSS targets.