### PR TITLE
[RELEASE ONLY CHANGES] Prepare tokenizers 1.4.1 with Python 3.14 wheels

### DIFF
--- a/.github/workflows/build-wheels-linux-aarch64.yml
+++ b/.github/workflows/build-wheels-linux-aarch64.yml
@@ -29,7 +29,7 @@ jobs:
       test-infra-ref: release/2.13
       with-cuda: disabled
       with-rocm: disabled
-      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
   build:
     name: Build Linux AArch64 wheels

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -29,7 +29,7 @@ jobs:
       test-infra-ref: release/2.13
       with-cuda: disabled
       with-rocm: disabled
-      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
   build:
     name: Build Linux wheels

--- a/.github/workflows/build-wheels-macos-arm64.yml
+++ b/.github/workflows/build-wheels-macos-arm64.yml
@@ -29,7 +29,7 @@ jobs:
       test-infra-ref: release/2.13
       with-cuda: disabled
       with-rocm: disabled
-      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
   build:
     name: Build macOS wheels

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -29,7 +29,7 @@ jobs:
       test-infra-ref: release/2.13
       with-cuda: disabled
       with-rocm: disabled
-      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
   build:
     name: Build Windows wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 # Python dependencies required for use.

--- a/pytorch_tokenizers/__init__.py
+++ b/pytorch_tokenizers/__init__.py
@@ -18,7 +18,7 @@ from .hf_tokenizer import HuggingFaceTokenizer
 from .llama2c import Llama2cTokenizer
 from .tiktoken import TiktokenTokenizer
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 try:
     from .pytorch_tokenizers_cpp import (  # @manual=//pytorch/tokenizers:pytorch_tokenizers_cpp

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ class BuildPy(build_py_orig):
 
 setup(
     name="pytorch-tokenizers",
-    version="1.4.0",
+    version="1.4.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/meta-pytorch/tokenizers",
@@ -193,6 +193,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: C++",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],

--- a/test/test_python_bindings.py
+++ b/test/test_python_bindings.py
@@ -91,7 +91,7 @@ class TestPythonBindings(unittest.TestCase):
     def test_version(self):
         """Test that version is available"""
         self.assertTrue(hasattr(pytorch_tokenizers, "__version__"))
-        self.assertEqual(pytorch_tokenizers.__version__, "1.4.0")
+        self.assertEqual(pytorch_tokenizers.__version__, "1.4.1")
 
     def test_hf_tokenizer_encode_decode(self):
         """Test HFTokenizer with test_hf_tokenizer.json to encode/decode 'Hello world!'"""


### PR DESCRIPTION
Release-only change. Do not merge to main.

The pytorch-tokenizers 1.4.0 release omitted Python 3.14 because all four release wheel matrices stopped at Python 3.13. This prevents the ExecuTorch 1.4 Windows Python 3.14 wheel from resolving its `pytorch-tokenizers>=1.4.0` dependency.

Prepare patch release 1.4.1:
- Add Python 3.14 to Linux x86_64, Linux AArch64, macOS arm64, and Windows wheel matrices.
- Advertise Python 3.14 support in package metadata.
- Bump the package and tested runtime version from 1.4.0 to 1.4.1.

Test plan:
- Parsed all four modified workflow YAML files.
- Compiled the modified Python files with `py_compile`.
- Parsed setup.py and pyproject.toml to verify version 1.4.1 and the Python 3.14 classifier.
- Verified all package/test version strings agree.
- `git diff --check`.
- Full release matrices delegated to CI and the v1.4.1 release event.

Authored with Codex.